### PR TITLE
feat: add Datadog MCP server and prds-get YOLO variant

### DIFF
--- a/.claude/skills/prds-get/SKILL.v1-yolo.md
+++ b/.claude/skills/prds-get/SKILL.v1-yolo.md
@@ -1,0 +1,48 @@
+---
+name: prds-get
+description: Fetch all open GitHub issues from this project that have the 'PRD' label
+category: project-management
+---
+
+# Get All PRDs
+
+Fetch all open GitHub issues from this project that have the 'PRD' label.
+
+**Note**: If any `gh` command fails with "command not found", inform the user that GitHub CLI is required and provide the installation link: https://cli.github.com/
+
+## Process
+
+1. **Fetch Issues**: Use GitHub CLI to get all open issues with PRD label
+   ```bash
+   gh issue list --label PRD --state open --json number,title,url,labels,assignees,createdAt,updatedAt
+   ```
+
+2. **Format Results**: Present the issues in a clear, organized format showing:
+   - Issue number and title
+   - Creation and last update dates
+   - Current assignees (if any)
+   - Direct link to the issue
+   - PRD file link (if available in issue description)
+
+3. **Meaningful Categorization**: Group PRDs by their actual purpose and impact, not generic labels:
+   - **Architecture & Infrastructure**: Core system changes, API designs, major refactors
+   - **User Experience**: Features that directly impact how users interact with the system
+   - **Developer Experience**: Tools, workflows, testing, documentation that help developers
+   - **AI & Intelligence**: Machine learning, AI-powered features, recommendation engines
+   - **Operations & Monitoring**: Deployment, scaling, observability, performance
+   - **Integration & Extensibility**: Third-party integrations, plugin systems, APIs
+
+   Each category should briefly explain what the PRDs in that group will accomplish for users or the system.
+
+4. **Priority Analysis**: If multiple PRDs exist, help identify:
+   - Which PRDs are most recently updated or have active discussion
+   - Which PRDs have dependencies on other PRDs
+   - Which PRDs are foundational vs. incremental improvements
+   - Which PRDs might be blocked or need clarification
+
+5. **Next Steps Suggestion**: Based on the PRD list, suggest logical next actions:
+   - Which PRD to work on next based on dependencies and impact
+   - PRDs that need attention, updates, or clarification
+   - Opportunities for parallel work on independent PRDs
+
+This provides a complete view of all active product requirements and helps with project planning and prioritization.

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,6 +10,10 @@
       "env": {
         "GITHUB_PAT": "${GITHUB_TOKEN}"
       }
+    },
+    "datadog-mcp": {
+      "type": "http",
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add the official Datadog remote MCP server (`mcp.datadoghq.com`) to `.mcp.json` for querying Datadog programmatically
- Create `SKILL.v1-yolo.md` for `prds-get` skill so `/make-autonomous` symlinks follow the same `SKILL.md` -> `SKILL.v1-yolo.md` pattern as all other PRD skills — fixes `prds-get` not being recognized after running `/make-autonomous` in other projects

## Test plan
- [x] Verified Datadog MCP server connects and returns data (confirmed logs from `dd-git-hooks` service)
- [x] Verified `prds-get` symlink updated in scaling-on-satisfaction to point to YOLO variant
- [ ] Run `/make-autonomous` in a fresh project and confirm `prds-get` appears in available skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new skill documentation for retrieving and categorizing GitHub PRD issues with priority analysis and dependency tracking capabilities.

* **Chores**
  * Added Datadog MCP server configuration for enhanced observability integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->