### PR TITLE
fix(scripts): add bank directory existence check to rename-anki-bank-images.sh

### DIFF
--- a/scripts/rename-anki-bank-images.sh
+++ b/scripts/rename-anki-bank-images.sh
@@ -6,6 +6,11 @@ set -e
 
 BANK="$HOME/Documents/Journal/anki/images/bank"
 
+if [[ ! -d "$BANK" ]]; then
+  echo "Error: Bank directory does not exist: $BANK"
+  exit 1
+fi
+
 # Map source screenshot names → descriptive bank names
 declare -a PAIRS=(
   "Screenshot 2026-04-04 at 8.32.57 AM.png|rainbow-cloud-bank.png"


### PR DESCRIPTION
## Description

**What does this PR do?**
Adds a guard check to `scripts/rename-anki-bank-images.sh` that validates the Anki image bank directory exists before attempting file operations.

**Why is this change needed?**
Without the check, if the bank directory doesn't exist, the script fails at `ls "$BANK"` with an unclear error. Since `set -e` is enabled, the loop operations would also fail silently.

## Related Issues

- Surfaced by CodeRabbit CLI review of PR #50 changes (advisory finding)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing Checklist

- [x] Manual testing performed
- [x] No tests needed — one-time utility script

## Breaking Changes

- [x] No

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] PR title follows Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in image processing with validation checks to ensure required resources exist before execution, preventing downstream failures and providing clearer error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->