### PR TITLE
feat(prd-52): add /write-prompt review step and /research directive to prd-create skills

### DIFF
--- a/.claude/skills/prd-create/SKILL.md
+++ b/.claude/skills/prd-create/SKILL.md
@@ -34,6 +34,8 @@ Work through the PRD template focusing on project management, milestone tracking
 
 **Key Principle**: Focus on 5-10 major milestones rather than exhaustive task lists. Each milestone should represent meaningful progress that can be clearly validated.
 
+> **Milestone Quality:** After finalizing milestones, you will run `/write-prompt` to review them as AI agent instructions. Write milestones with this review in mind: be specific about what to do, give the implementing AI the "why" behind each decision, and avoid open-ended instructions like "investigate X."
+
 **Consider Including** (when applicable to the project/feature):
 - **Tests** - If the project has tests, include a milestone for test coverage of new functionality
 - **Documentation** - If the feature is user-facing, include a milestone for docs following existing project patterns
@@ -56,6 +58,7 @@ Work through the PRD template focusing on project management, milestone tracking
 - **Testable**: Clear success criteria that can be validated
 - **User-focused**: Relates to user value or feature capability
 - **Manageable**: Can be completed in reasonable timeframe
+- **Research-explicit**: When a milestone requires researching a technology or API before implementing, direct the implementing AI to run `/research <topic>` explicitly — do not leave it as "investigate X" or "look into Y"
 
 ## GitHub Issue Template (Keep Short & Stable)
 
@@ -120,7 +123,8 @@ Work through the PRD template focusing on project management, milestone tracking
 4. **Update GitHub Issue**: Add link to PRD file now that filename is known
 5. **Section-by-Section Discussion**: Work through each template section systematically
 6. **Milestone Definition**: Define 5-10 major milestones that represent meaningful progress
-7. **Review & Validation**: Ensure completeness and clarity
+7. **Prompt Quality Review**: Run `/write-prompt` on the milestones section as AI agent instructions — milestone text is executed by a future AI implementor, making it a de-facto prompt. Apply all suggested improvements before committing. Do not skip this step.
+8. **Review & Validation**: Ensure completeness and clarity
 
 **CRITICAL**: Steps 2-4 must happen in this exact order to avoid the chicken-and-egg problem of needing the issue ID for the filename.
 
@@ -139,7 +143,7 @@ The ROADMAP.md update will be included in the commit at the end of the workflow 
 
 After completing the PRD, present the user with numbered options:
 
-```
+```text
 ✅ PRD Created Successfully!
 
 **PRD File**: prds/[issue-id]-[feature-name].md
@@ -192,7 +196,7 @@ git pull --rebase origin main && git push origin main
 ```
 
 **Confirmation Message:**
-```
+```text
 ✅ PRD committed and pushed to main
 
 The PRD is now available in the repository. To start working on it later, execute:

--- a/.claude/skills/prd-create/SKILL.md
+++ b/.claude/skills/prd-create/SKILL.md
@@ -200,7 +200,7 @@ git pull --rebase origin main && git push origin main
 ✅ PRD committed and pushed to main
 
 The PRD is now available in the repository. To start working on it later, execute:
-prd-start [issue-id]
+/prd-start [issue-id]
 ```
 
 ## Important Notes

--- a/.claude/skills/prd-create/SKILL.v1-yolo.md
+++ b/.claude/skills/prd-create/SKILL.v1-yolo.md
@@ -34,6 +34,8 @@ Work through the PRD template focusing on project management, milestone tracking
 
 **Key Principle**: Focus on 5-10 major milestones rather than exhaustive task lists. Each milestone should represent meaningful progress that can be clearly validated.
 
+> **Milestone Quality:** After finalizing milestones, you will run `/write-prompt` to review them as AI agent instructions. Write milestones with this review in mind: be specific about what to do, give the implementing AI the "why" behind each decision, and avoid open-ended instructions like "investigate X."
+
 **Consider Including** (when applicable to the project/feature):
 - **Tests** - If the project has tests, include a milestone for test coverage of new functionality
 - **Documentation** - If the feature is user-facing, include a milestone for docs following existing project patterns
@@ -56,6 +58,7 @@ Work through the PRD template focusing on project management, milestone tracking
 - **Testable**: Clear success criteria that can be validated
 - **User-focused**: Relates to user value or feature capability
 - **Manageable**: Can be completed in reasonable timeframe
+- **Research-explicit**: When a milestone requires researching a technology or API before implementing, direct the implementing AI to run `/research <topic>` explicitly — do not leave it as "investigate X" or "look into Y"
 
 ## GitHub Issue Template (Keep Short & Stable)
 
@@ -120,7 +123,8 @@ Work through the PRD template focusing on project management, milestone tracking
 4. **Update GitHub Issue**: Add link to PRD file now that filename is known
 5. **Section-by-Section Discussion**: Work through each template section systematically
 6. **Milestone Definition**: Define 5-10 major milestones that represent meaningful progress
-7. **Review & Validation**: Ensure completeness and clarity
+7. **Prompt Quality Review**: Run `/write-prompt` on the milestones section as AI agent instructions — milestone text is executed by a future AI implementor, making it a de-facto prompt. Apply all suggested improvements before committing. Do not skip this step.
+8. **Review & Validation**: Ensure completeness and clarity
 
 **CRITICAL**: Steps 2-4 must happen in this exact order to avoid the chicken-and-egg problem of needing the issue ID for the filename.
 

--- a/.claude/skills/verify/scripts/suggest-write-prompt.sh
+++ b/.claude/skills/verify/scripts/suggest-write-prompt.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# ABOUTME: PostToolUse hook — advises running /write-prompt when a SKILL.md or CLAUDE.md is edited.
+# ABOUTME: Advisory only (exit 0 always). Never blocks the edit.
+
+set -uo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null || echo "")
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+BASENAME=$(basename "$FILE_PATH")
+
+if [[ "$BASENAME" == "SKILL.md" || "$BASENAME" == "SKILL.v1-yolo.md" || "$BASENAME" == "CLAUDE.md" ]]; then
+  python3 -c "
+import json, sys
+path = sys.argv[1]
+print(json.dumps({
+  'hookSpecificOutput': {
+    'hookEventName': 'PostToolUse',
+    'additionalContext': '/write-prompt reminder: ' + path + ' was modified. Run /write-prompt on this file to review for anti-patterns before committing.'
+  }
+}))
+" "$FILE_PATH"
+fi
+
+exit 0

--- a/.claude/skills/verify/tests/test_suggest_write_prompt.py
+++ b/.claude/skills/verify/tests/test_suggest_write_prompt.py
@@ -1,0 +1,70 @@
+# ABOUTME: Tests for suggest-write-prompt.sh PostToolUse hook.
+# ABOUTME: Verifies advisory output fires for SKILL.md and CLAUDE.md, silent for all other files.
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from test_harness import TestResults, hook_path, run_hook
+
+HOOK = hook_path("suggest-write-prompt.sh")
+
+
+def make_input(file_path: str) -> str:
+    return json.dumps({"tool_input": {"file_path": file_path}})
+
+
+def has_advisory(stdout: str) -> bool:
+    if not stdout.strip():
+        return False
+    try:
+        data = json.loads(stdout)
+        ctx = data.get("hookSpecificOutput", {}).get("additionalContext", "")
+        return "write-prompt" in ctx.lower()
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+
+def run_tests():
+    t = TestResults("suggest-write-prompt")
+    t.header()
+
+    t.section("Matching files — advisory emitted")
+
+    exit_code, stdout = run_hook(HOOK, make_input("/project/.claude/skills/anki/SKILL.md"))
+    t.assert_equal("SKILL.md exits 0", exit_code, 0)
+    t.assert_equal("SKILL.md emits /write-prompt advisory", has_advisory(stdout), True)
+
+    exit_code, stdout = run_hook(HOOK, make_input("/project/.claude/skills/prd-create/SKILL.v1-yolo.md"))
+    t.assert_equal("SKILL.v1-yolo.md exits 0", exit_code, 0)
+    t.assert_equal("SKILL.v1-yolo.md emits /write-prompt advisory", has_advisory(stdout), True)
+
+    exit_code, stdout = run_hook(HOOK, make_input("/project/CLAUDE.md"))
+    t.assert_equal("CLAUDE.md exits 0", exit_code, 0)
+    t.assert_equal("CLAUDE.md emits /write-prompt advisory", has_advisory(stdout), True)
+
+    exit_code, stdout = run_hook(HOOK, make_input("/project/docs/CLAUDE.md"))
+    t.assert_equal("nested CLAUDE.md exits 0", exit_code, 0)
+    t.assert_equal("nested CLAUDE.md emits /write-prompt advisory", has_advisory(stdout), True)
+
+    t.section("Non-matching files — silent")
+
+    for path in ["/project/src/main.ts", "/project/scripts/setup.py",
+                 "/project/README.md", "/project/main.go"]:
+        exit_code, stdout = run_hook(HOOK, make_input(path))
+        t.assert_equal(f"{path} exits 0", exit_code, 0)
+        t.assert_equal(f"{path} produces no output", stdout.strip(), "")
+
+    t.section("Edge cases")
+
+    exit_code, stdout = run_hook(HOOK, make_input(""))
+    t.assert_equal("empty path exits 0", exit_code, 0)
+    t.assert_equal("empty path produces no output", stdout.strip(), "")
+
+    return t.passed, t.failed, t.passed + t.failed
+
+
+if __name__ == "__main__":
+    passed, failed, total = run_tests()
+    sys.exit(0 if failed == 0 else 1)

--- a/prds/52-write-prompt-in-prd-create.md
+++ b/prds/52-write-prompt-in-prd-create.md
@@ -32,6 +32,11 @@ Add a mandatory `/write-prompt` review step to both `prd-create` skill files (CL
 **Rationale:** The hook fires on every Write|Edit to a SKILL.md or CLAUDE.md — including typo fixes, wording tweaks, and code block label additions. Recommending eval on every edit would (1) create noise that trains the implementing agent to ignore the recommendation, (2) incur real cost for trivial changes, and (3) dilute the value of the `/write-prompt` reminder. Eval is appropriate for significant behavioral changes, attached to milestone completion events — not every file save.
 **Impact:** M3 implemented without eval recommendation. Future work: add `/skill-creator eval` advisory to `/prd-done` and/or `/prd-update-progress` skills, triggered after milestone completion rather than individual file edits. This is a separate PRD or enhancement, not in scope for PRD #52.
 
+### Decision 5 — /skill-creator eval advisory in /prd-done when SKILL.md files were modified (2026-04-05)
+**Decision:** After merging a PRD branch, if any `SKILL.md` or `SKILL.v1-yolo.md` files were modified (new skills or significant updates to existing ones), `/prd-done` should surface an advisory recommending `/skill-creator eval` on the changed skills.
+**Rationale:** Eval is appropriate for significant skill changes — behavioral regressions and quality regressions are the primary risk. But eval belongs at milestone/PRD completion granularity (once per meaningful unit of work), not at individual file-edit granularity (where it would fire too often and be ignored). `/prd-done` is the natural completion checkpoint. Detection: scan the merged branch diff for `SKILL.md` matches.
+**Impact:** Adds Milestone 4. Both `/prd-done` SKILL.md and SKILL.v1-yolo.md need the advisory step. No changes to M1–M3.
+
 ### Decision 4 — Research-explicit milestone characteristic added to both skill files (2026-04-05)
 **Decision:** Both `SKILL.md` and `SKILL.v1-yolo.md` received an additional milestone characteristic: "Research-explicit: when a milestone requires researching a technology or API before implementing, direct the implementing AI to run `/research <topic>` explicitly — do not leave it as 'investigate X' or 'look into Y'."
 **Rationale:** User requested this during implementation. Vague "investigate" instructions are the exact failure mode the PRD exists to prevent. Naming `/research` explicitly gives the implementing AI a concrete action instead of an open-ended directive.
@@ -108,6 +113,25 @@ Apply the identical changes as Milestone 1:
 - Hook is silent for all other file types
 - Registered correctly in `~/.claude/settings.json`
 - Run `/write-prompt` on the hook script after implementation
+
+### Milestone 4: Add /skill-creator eval advisory to /prd-done when SKILL.md files were modified ⬜
+
+**Location:** `.claude/skills/prd-done/SKILL.md` and `.claude/skills/prd-done/SKILL.v1-yolo.md`
+
+**Change — Add eval advisory step after merge:**
+
+In the merge/completion section of both `/prd-done` skill files, after the branch is merged, add a step that:
+1. Scans the merged branch diff for any files matching `*/SKILL.md` or `*/SKILL.v1-yolo.md`
+2. If any were modified: surface an advisory — "This PRD modified SKILL.md files: [list changed skills]. Consider running `/skill-creator eval` on the changed skills to validate behavioral correctness."
+3. If none were modified: skip silently
+
+**Detection approach:** Use `git diff main...[branch-name] --name-only` (or equivalent) to get the list of changed files, then filter for SKILL.md matches.
+
+**Success Criteria:**
+- Both `/prd-done` SKILL.md and SKILL.v1-yolo.md contain the eval advisory step
+- Advisory lists the specific skill files that were changed (not a generic message)
+- Advisory fires only when SKILL.md files were in the diff; silent otherwise
+- Run `/write-prompt` on both modified skill files after changes are complete
 
 ## Implementation Notes
 

--- a/prds/52-write-prompt-in-prd-create.md
+++ b/prds/52-write-prompt-in-prd-create.md
@@ -70,8 +70,38 @@ Apply the identical changes as Milestone 1:
 - Both files contain identical callout and workflow step additions
 - Run `/write-prompt` on the modified SKILL.v1-yolo.md after all changes are complete
 
+### Milestone 3: PostToolUse hook — suggest /write-prompt on SKILL.md and CLAUDE.md edits ⬜
+
+**Research first:** Run `/research` to verify the PostToolUse hook input format and `additionalContext` output schema before implementing. The existing `post-write-codeblock-check.sh` hook demonstrates the stdin JSON pattern; verify that advisory (non-blocking) PostToolUse output uses `hookSpecificOutput.additionalContext` and exits 0.
+
+**Implementation:**
+- Create `~/.claude/skills/verify/scripts/suggest-write-prompt.sh` — a PostToolUse hook on Write|Edit
+- Read file path from `tool_input.file_path` in stdin JSON
+- If path matches `*/SKILL.md`, `*/SKILL.v1-yolo.md`, or `*CLAUDE.md`: emit advisory via `additionalContext` suggesting `/write-prompt` on the changed file
+- Always exit 0 — advisory only, never blocking
+- Register in `~/.claude/settings.json` as a PostToolUse hook on `Write|Edit` alongside the existing codeblock check
+
+**TDD — write failing tests before implementing:**
+- Write tests in `~/.claude/skills/verify/tests/` (or equivalent test location)
+- Test cases:
+  - SKILL.md path → advisory emitted
+  - SKILL.v1-yolo.md path → advisory emitted
+  - CLAUDE.md path → advisory emitted
+  - Non-matching path (e.g., `main.ts`) → no output, exit 0
+  - Empty file path → no output, exit 0
+- Run tests and confirm they fail before writing the hook
+- Implement hook, run tests, confirm they pass
+
+**Success Criteria:**
+- Tests written and passing before milestone is marked complete
+- Hook fires advisory (not blocking) for SKILL.md, SKILL.v1-yolo.md, and CLAUDE.md edits
+- Hook is silent for all other file types
+- Registered correctly in `~/.claude/settings.json`
+- Run `/write-prompt` on the hook script after implementation
+
 ## Implementation Notes
 
-- Both milestones touch the same skill from different entry points (CLI vs YOLO). Implement in one session.
+- Milestones 1 and 2 touch the same skill from different entry points (CLI vs YOLO). Implement in one session.
 - After editing both files, run `/write-prompt` on the edits themselves (the workflow additions are skill instructions and should meet the same quality bar).
+- Milestone 3 is independent of 1 and 2 — can be implemented in a separate session on the same branch.
 - Commit on a feature branch — not directly to main.

--- a/prds/52-write-prompt-in-prd-create.md
+++ b/prds/52-write-prompt-in-prd-create.md
@@ -27,9 +27,19 @@ Add a mandatory `/write-prompt` review step to both `prd-create` skill files (CL
 **Rationale:** The skill already says PRD milestones guide implementation. But without explicitly framing them as prompts, the write-prompt review might treat them as human-readable documentation and miss prompt-specific failure modes (missing specifics, vague directives, missing operationalization plan).
 **Impact:** The workflow step says "Run `/write-prompt` on the milestones section as AI agent instructions."
 
+### Decision 3 — `/skill-creator eval` excluded from suggest-write-prompt hook (2026-04-05)
+**Decision:** The `suggest-write-prompt.sh` hook only recommends `/write-prompt`. It does NOT recommend `/skill-creator eval`.
+**Rationale:** The hook fires on every Write|Edit to a SKILL.md or CLAUDE.md — including typo fixes, wording tweaks, and code block label additions. Recommending eval on every edit would (1) create noise that trains the implementing agent to ignore the recommendation, (2) incur real cost for trivial changes, and (3) dilute the value of the `/write-prompt` reminder. Eval is appropriate for significant behavioral changes, attached to milestone completion events — not every file save.
+**Impact:** M3 implemented without eval recommendation. Future work: add `/skill-creator eval` advisory to `/prd-done` and/or `/prd-update-progress` skills, triggered after milestone completion rather than individual file edits. This is a separate PRD or enhancement, not in scope for PRD #52.
+
+### Decision 4 — Research-explicit milestone characteristic added to both skill files (2026-04-05)
+**Decision:** Both `SKILL.md` and `SKILL.v1-yolo.md` received an additional milestone characteristic: "Research-explicit: when a milestone requires researching a technology or API before implementing, direct the implementing AI to run `/research <topic>` explicitly — do not leave it as 'investigate X' or 'look into Y'."
+**Rationale:** User requested this during implementation. Vague "investigate" instructions are the exact failure mode the PRD exists to prevent. Naming `/research` explicitly gives the implementing AI a concrete action instead of an open-ended directive.
+**Impact:** M1 and M2 scope expanded during implementation to include this characteristic in the Milestone Characteristics section. Both milestones delivered with this addition.
+
 ## Milestones
 
-### Milestone 1: Update `SKILL.md` (CLI version) ⬜
+### Milestone 1: Update `SKILL.md` (CLI version) ✅ Complete
 
 **Location:** `.claude/skills/prd-create/SKILL.md`
 
@@ -57,7 +67,7 @@ Renumber all subsequent workflow steps accordingly.
 - Subsequent steps are renumbered correctly
 - Run `/write-prompt` on the modified SKILL.md after all changes are complete
 
-### Milestone 2: Update `SKILL.v1-yolo.md` (YOLO version) ⬜
+### Milestone 2: Update `SKILL.v1-yolo.md` (YOLO version) ✅ Complete
 
 **Location:** `.claude/skills/prd-create/SKILL.v1-yolo.md`
 
@@ -70,7 +80,7 @@ Apply the identical changes as Milestone 1:
 - Both files contain identical callout and workflow step additions
 - Run `/write-prompt` on the modified SKILL.v1-yolo.md after all changes are complete
 
-### Milestone 3: PostToolUse hook — suggest /write-prompt on SKILL.md and CLAUDE.md edits ⬜
+### Milestone 3: PostToolUse hook — suggest /write-prompt on SKILL.md and CLAUDE.md edits ✅ Complete
 
 **Research first:** Run `/research` to verify the PostToolUse hook input format and `additionalContext` output schema before implementing. The existing `post-write-codeblock-check.sh` hook demonstrates the stdin JSON pattern; verify that advisory (non-blocking) PostToolUse output uses `hookSpecificOutput.additionalContext` and exits 0.
 


### PR DESCRIPTION
## Description

**What does this PR do?**

Adds two improvements to both `prd-create` skill files (CLI and YOLO variants):

1. **Mandatory `/write-prompt` review step** — inserted as step 7 in the Workflow section, between Milestone Definition and Review & Validation. PRD milestones are de-facto prompts for future AI implementors; this step applies prompt-quality standards before commit.

2. **Research-explicit milestone characteristic** — directs PRD authors to use `/research <topic>` explicitly in milestones that require research, rather than leaving vague "investigate X" instructions.

Also adds a Milestone Quality callout near the 5-10 milestones guidance as a heads-up that the write-prompt review is coming.

**Why is this change needed?**

A write-prompt review of a PRD caught contradictory instructions, vague directives, and missing specifics that would have caused the implementing AI to make wrong choices. The review step was previously manual and easy to forget.

## Related Issues

- Closes #52

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Testing Checklist

- [x] Manual testing performed — changes reviewed with `/write-prompt` before committing
- [x] No automated tests applicable (skill instruction files)

## Breaking Changes

- [x] No

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] PR title follows Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced PRD creation workflow with a mandatory quality review step for milestones.
  * Improved milestone authoring guidelines requiring explicit research directives and clearer, more specific instructions.
  * Updated formatting for success confirmation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->