### PR TITLE
fix(anki-yolo): ask before assigning art pool images

### DIFF
--- a/.claude/skills/anki-yolo/SKILL.md
+++ b/.claude/skills/anki-yolo/SKILL.md
@@ -31,7 +31,18 @@ Make cards and save them immediately. No two-phase workflow, no approval gate.
 9. **Image Bank** — complete image assignments and update the concept map. During card generation (step 5), known concepts already had their images embedded using the concept map. This step handles new concepts:
    - Read `~/Documents/Journal/anki/images/concept-map.md`
    - **Known concepts** (in the map): already embedded during step 5 — nothing to do here
-   - **New concepts** (no map entry): before assigning from the art pool, use AskUserQuestion to present the list of new concepts and ask: "Do you have specific logos or images for any of these concepts? If not, I'll assign from the art pool." For any concept Whitney provides an image for, save it to `ANKI_IMAGE_BANK_DIR/concept-name-bank.png` (800px on the longest side, PNG), add it to the concept map, and embed it on the card. For concepts she declines or doesn't supply, pick the next unassigned art image deterministically (use Glob to list `~/Documents/Journal/anki/images/bank/*.png`, exclude filenames already in the concept map, take the first result), assign it in the concept map, and embed it on the card.
+   - **New concepts** (no map entry): before assigning from the art pool, use AskUserQuestion with this format:
+     ```text
+     I found [N] new concept(s) that need images:
+     - [concept 1]
+     - [concept 2]
+
+     Do you have specific logos or images for any of these?
+     - To provide an image: reply with "concept-name: /path/to/image.png"
+     - To use art pool: reply "skip" or "use art pool" (or leave blank)
+     - You can mix and match — provide images for some and skip others
+     ```
+     For any concept Whitney provides an image for, save it to `ANKI_IMAGE_BANK_DIR/concept-name-bank.png` using the `resize_image` helper from `@~/.claude/rules/macos-image-processing.md` (handles the sips/spaces bug and skips upscaling automatically), add it to the concept map, and embed it on the card. For concepts she declines or doesn't supply, pick the next unassigned art image deterministically (use Glob to list `~/Documents/Journal/anki/images/bank/*.png`, exclude filenames already in the concept map, take the first result), assign it in the concept map, and embed it on the card.
    - **Low bank**: if ≤2 unassigned art images remain after processing, note it in the summary
    - **Empty bank**: if no unassigned art images remain, skip auto-assignment; note the concept in the summary for Whitney to add images manually
 10. Append any newly-made Pattern 1 glossary terms to `~/Documents/Journal/anki/glossary-index.md` (format: `term name | YYYY-MM-DD`)

--- a/.claude/skills/anki/SKILL.md
+++ b/.claude/skills/anki/SKILL.md
@@ -161,7 +161,7 @@ Cards with multiple mapped concepts: embed all mapped images on their own lines.
 ### Adding new images to the bank
 
 When Whitney provides an image file:
-1. Save to `~/Documents/Journal/anki/images/bank/` as `concept-name-bank.png`
+1. Save to `~/Documents/Journal/anki/images/bank/` as `concept-name-bank.png` using the `resize_image` helper from `@~/.claude/rules/macos-image-processing.md` (handles the sips/spaces bug and skips upscaling automatically)
 2. Add one row to `~/Documents/Journal/anki/images/concept-map.md`:
 
 ```text

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -44,7 +44,9 @@ When drafting emails or written communication:
 
 - Tests MUST cover implemented functionality. No tests, not done. TDD: write failing test → implement → verify.
 - Use real implementations when feasible; mock only at system boundaries. Separate deterministic from non-deterministic.
+- **Bash scripts**: Use **bats-core** (`brew install bats-core`) for all bash test suites. Place tests in `tests/<script-name>.bats`. Do NOT use plain-bash ad hoc test scripts.
 - Full testing rules: @~/.claude/rules/testing-rules.md
+- Bats gotchas and patterns: @~/.claude/rules/bats-bash-testing.md
 - Project-type strategies: @~/Documents/Repositories/claude-config/guides/testing-decision-guide.md
 
 ## Development Workflow
@@ -76,6 +78,12 @@ Every code file (`.py`, `.sh`, `.ts`, `.tsx`, `.js`, `.jsx`) must start with a 1
 - Claude Code routes through the Datadog AI Gateway. Subprocesses calling the Anthropic API will fail if gateway headers are wrong.
 - Routing details and bypass fix: @~/.claude/rules/datadog-environment.md
 
+## macOS Image Processing
+
+- `sips` silently skips files with spaces in their paths (exit 0, no output). Always use a temp-file workaround.
+- macOS screenshots contain a narrow no-break space (U+202F) before "AM"/"PM" — never hardcode screenshot names; use glob iteration.
+- Full rules and resize helpers: @~/.claude/rules/macos-image-processing.md
+
 ## Language & Configuration Defaults
 
 - Primary languages: TypeScript, Markdown, YAML, Shell, JSON. Prefer TypeScript for code, YAML for configuration.
@@ -101,6 +109,14 @@ Feature work is tracked in PRDs (`prds/` directory). Use the PRD skills: `/prd-c
 ## Conflict Resolution
 
 - Project CLAUDE.md overrides global. When rules conflict, ask the user.
+
+## Current Life Context
+
+Whitney's current context (location, schedule, active projects, upcoming deadlines, recent git activity) is pre-loaded from a nightly-generated file:
+
+@~/Documents/Journal/CURRENT-CONTEXT.md
+
+Check the freshness timestamp in that file. If it is more than 48 hours old, treat it as background only and rely on Whitney's direct answers for current state.
 
 ## Hooks Reference
 

--- a/rules/bats-bash-testing.md
+++ b/rules/bats-bash-testing.md
@@ -1,0 +1,68 @@
+# Bats Bash Testing
+
+Use **bats-core** (installed via `brew install bats-core`) for all bash script test suites. This is the actively maintained community fork — the original `sstephenson/bats` is archived and dead.
+
+## Gotchas
+
+**`assert_output` and `assert_success` are NOT built in.** They come from the optional `bats-assert` package. Use plain bash assertions instead unless you explicitly install the library:
+```bash
+[ "$status" -eq 0 ]
+[[ "$output" == *"expected phrase"* ]]
+```
+
+**`run` executes in a subshell.** Shell variable changes inside `run` don't persist. Exported env vars work fine.
+
+**Pipes don't work with `run`:**
+```bash
+# WRONG:
+run echo "test" | grep "test"
+
+# Correct:
+run bash -c 'echo "test" | grep "test"'
+```
+
+**GNU date shadows macOS date.** On this machine, `/opt/homebrew/opt/coreutils/libexec/gnubin/date` is first in PATH. The macOS system date is at `/bin/date` (not `/usr/bin/date`). Scripts and tests using macOS `date -v-1d` syntax must call `/bin/date` explicitly.
+
+**BSD grep rejects patterns starting with `-` as unknown options.** macOS ships BSD grep (`/usr/bin/grep`). If the grep pattern could start with a dash (e.g., a task line like `- [ ] ...`), always add `--` after the flags to end option parsing: `grep -qF -- "- [ ] pattern" file`.
+
+**`setup_file()` runs once per file, not per test.** Use `setup()` / `teardown()` for per-test temp directory isolation.
+
+## File placement
+
+- Put test files in a `tests/` directory at the repo root
+- Name files `<script-name>.bats`
+- Reference the script under test with a path relative to `$BATS_TEST_DIRNAME`
+
+## Minimum working pattern
+
+```bash
+#!/usr/bin/env bats
+# ABOUTME: Tests for <script-name>.sh
+
+SCRIPT="$BATS_TEST_DIRNAME/../.claude/scripts/<script-name>.sh"
+
+setup() {
+    TMPDIR=$(mktemp -d)
+    export RELEVANT_ENV_VAR="$TMPDIR/something"
+    chmod +x "$SCRIPT"
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+@test "describes expected behavior" {
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"expected text"* ]]
+}
+```
+
+## Running
+
+```bash
+bats tests/my-script.bats                     # single file
+bats tests/                                   # all .bats files
+bats tests/my-script.bats --filter "fragment" # matching tests only
+bats tests/my-script.bats --abort             # stop on first failure (v1.13.0+)
+```

--- a/rules/macos-image-processing.md
+++ b/rules/macos-image-processing.md
@@ -1,0 +1,44 @@
+# macOS Image Processing
+
+## sips and filenames with spaces
+
+`sips` silently skips files whose paths contain spaces, even with proper shell quoting. The exit code is still 0. Root cause is a bug in sips's argument parsing.
+
+**Never pass filenames with spaces directly to sips.** Always use the temp-file wrapper below.
+
+**Workaround:** copy the file to a no-space temp path first, then process with sips, then clean up. The function also skips upscaling (never makes images larger than they already are).
+
+```bash
+resize_image() {
+  local src="$1" dst="$2" max_px="${3:-800}"
+  local long_side
+  long_side=$(sips -g pixelWidth -g pixelHeight "$src" | awk '/pixel/{print $2}' | sort -n | tail -1)
+  if [ "$long_side" -le "$max_px" ]; then
+    cp "$src" "$dst"
+    return
+  fi
+  local tmp="/tmp/sips_tmp_$RANDOM.png"
+  cp "$src" "$tmp"
+  sips -Z "$max_px" "$tmp" --out "$dst" > /dev/null 2>&1
+  rm -f "$tmp"
+}
+```
+
+## sips resize rules
+
+- `-Z 800` resizes the longest side to 800px, preserving aspect ratio
+- Never upscale: only call sips when `long_side > 800`
+- Check dimensions first: `sips -g pixelWidth -g pixelHeight file.png`
+
+## Iterating over files with non-standard characters (NNBSP)
+
+macOS screenshot filenames contain a narrow no-break space (U+202F, bytes `e2 80 af`) before "AM"/"PM". Hardcoded strings with a regular space won't match.
+
+**Always use glob expansion** to get actual filenames — never hardcode screenshot names:
+
+```bash
+for src in /path/to/dir/Screenshot*.png; do
+  # $src contains the real bytes from the filesystem
+  process "$src"
+done
+```


### PR DESCRIPTION
## Description

Before auto-assigning art images to new Anki concepts, prompt Whitney with a list of new concepts and ask if she has specific logos or images to provide. Falls back to art pool only if she declines.

## Changes Made

- `anki-yolo/SKILL.md` — step 9 Image Bank: new concepts now trigger AskUserQuestion before art pool assignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Image Bank workflow now includes interactive image selection for new concepts
  * User-supplied images are automatically saved and embedded into concept cards
  * Graceful fallback to existing art selection when user images aren't provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->