### PR TITLE
fix(settings): narrow Bash(rm *) allow rule to safe patterns

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -39,7 +39,9 @@
       "Bash(npm ci*)",
       "Bash(git pull*)",
       "Bash(git push*)",
-      "Bash(rm *)",
+      "Bash(rm *.tmp)",
+      "Bash(rm *.log)",
+      "Bash(rm -f *.tmp)",
       "Bash(mkdir *)",
       "Bash(coderabbit *)",
       "Bash(gog *)",
@@ -104,7 +106,8 @@
       "Bash(git rebase*)",
       "Bash(git branch -D*)",
       "Bash(gh pr merge*)",
-      "Bash(npm publish*)"
+      "Bash(npm publish*)",
+      "Bash(rm *)"
     ]
   },
   "model": "sonnet[1m]",


### PR DESCRIPTION
## Summary

- Moves `Bash(rm *)` from `allow` to `ask`, requiring confirmation for any `rm` that isn't explicitly safe
- Adds targeted `allow` rules for common safe patterns: `rm *.tmp`, `rm *.log`, `rm -f *.tmp`

Closes #64

## Test plan

- [ ] Verify `rm somefile.tmp` runs without prompt
- [ ] Verify `rm somefile.log` runs without prompt  
- [ ] Verify `rm -f somefile.tmp` runs without prompt
- [ ] Verify `rm -rf ./some-dir/` prompts for confirmation
- [ ] Verify `rm important.json` prompts for confirmation