### PR TITLE
fix(hooks): parse pre-push stdin for accurate ref detection; fix pnpm/yarn executor

### DIFF
--- a/hooks/git/checks/pre-push-verify.sh
+++ b/hooks/git/checks/pre-push-verify.sh
@@ -15,14 +15,36 @@ REMOTE_URL="${2:-}"
 # Get project directory (the git repo root)
 PROJECT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
+# Read pre-push payload from stdin (git provides: local_ref local_sha remote_ref remote_sha).
+# Must be captured before any subshell or pipeline consumes stdin.
+PUSH_STDIN=$(cat)
+
 # Compute diff base for scoping security checks to branch changes only.
-# Prefer upstream tracking ref; fall back to origin/main or origin/master.
-DIFF_BASE=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo "")
+# Primary: derive from the stdin push payload using the actual remote name (handles
+# non-origin remotes and detached HEAD). Fallback: upstream tracking ref, then
+# well-known base refs.
+DIFF_BASE=""
+if [[ -n "$PUSH_STDIN" ]]; then
+    while IFS=' ' read -r local_ref _local_sha remote_ref _remote_sha; do
+        [[ -z "$local_ref" ]] && continue
+        if [[ "$remote_ref" == refs/heads/* ]] && [[ -n "$REMOTE_NAME" ]]; then
+            remote_branch="${remote_ref#refs/heads/}"
+            if git rev-parse --verify "$REMOTE_NAME/$remote_branch" &>/dev/null; then
+                DIFF_BASE="$REMOTE_NAME/$remote_branch"
+            fi
+        fi
+        break  # use first ref; multi-ref pushes share the same diff base
+    done <<< "$PUSH_STDIN"
+fi
+
 if [[ -z "$DIFF_BASE" ]]; then
-    if git rev-parse --verify origin/main &>/dev/null; then
-        DIFF_BASE="origin/main"
-    elif git rev-parse --verify origin/master &>/dev/null; then
-        DIFF_BASE="origin/master"
+    DIFF_BASE=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo "")
+fi
+if [[ -z "$DIFF_BASE" ]]; then
+    if git rev-parse --verify "${REMOTE_NAME:-origin}/main" &>/dev/null; then
+        DIFF_BASE="${REMOTE_NAME:-origin}/main"
+    elif git rev-parse --verify "${REMOTE_NAME:-origin}/master" &>/dev/null; then
+        DIFF_BASE="${REMOTE_NAME:-origin}/master"
     fi
 fi
 
@@ -37,7 +59,20 @@ fi
 
 # Detect if pushing to a branch with an open PR.
 # If so, escalate to expanded security + tests to catch post-review regressions.
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+# Derive BRANCH from stdin payload (handles detached HEAD); fall back to local state.
+BRANCH=""
+if [[ -n "$PUSH_STDIN" ]]; then
+    while IFS=' ' read -r local_ref _local_sha _remote_ref _remote_sha; do
+        [[ -z "$local_ref" ]] && continue
+        if [[ "$local_ref" == refs/heads/* ]]; then
+            BRANCH="${local_ref#refs/heads/}"
+        fi
+        break
+    done <<< "$PUSH_STDIN"
+fi
+if [[ -z "$BRANCH" ]]; then
+    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+fi
 HAS_PR=false
 
 if [[ -n "$BRANCH" && "$BRANCH" != "HEAD" ]] && command -v gh &>/dev/null; then
@@ -89,10 +124,10 @@ fi
 # Advisory CodeRabbit CLI review (runs after blocking checks pass; never blocks push)
 if [[ ! -f "$PROJECT_DIR/.skip-coderabbit" ]]; then
     REVIEW_BASE=""
-    if git rev-parse --verify origin/main &>/dev/null; then
-        REVIEW_BASE="origin/main"
-    elif git rev-parse --verify origin/master &>/dev/null; then
-        REVIEW_BASE="origin/master"
+    if git rev-parse --verify "${REMOTE_NAME:-origin}/main" &>/dev/null; then
+        REVIEW_BASE="${REMOTE_NAME:-origin}/main"
+    elif git rev-parse --verify "${REMOTE_NAME:-origin}/master" &>/dev/null; then
+        REVIEW_BASE="${REMOTE_NAME:-origin}/master"
     fi
 
     if [[ -n "$REVIEW_BASE" ]]; then

--- a/hooks/git/lib/detect-project.sh
+++ b/hooks/git/lib/detect-project.sh
@@ -167,11 +167,22 @@ except Exception:
     PKG_MANAGER="bun"
   fi
 
+  # Map package manager to executor for fallback commands.
+  # Yarn Berry (PnP) requires 'yarn dlx'; classic Yarn uses 'yarn'; npm/pnpm use npx.
+  EXEC="npx"
+  if [ "$PKG_MANAGER" = "yarn" ]; then
+    if [ -f "$PROJECT_DIR/.yarnrc.yml" ]; then
+      EXEC="yarn dlx"
+    else
+      EXEC="yarn"
+    fi
+  fi
+
   # Detect build command
   if echo "$SCRIPTS_JSON" | python3 -c "import json,sys; sys.exit(0 if 'build' in json.load(sys.stdin) else 1)" 2>/dev/null; then
     CMD_BUILD="$PKG_MANAGER run build"
   elif [ "$HAS_TSCONFIG" = true ]; then
-    CMD_BUILD="npx tsc --noEmit"
+    CMD_BUILD="$EXEC tsc --noEmit"
   fi
 
   # Detect typecheck command
@@ -180,23 +191,23 @@ except Exception:
   elif echo "$SCRIPTS_JSON" | python3 -c "import json,sys; sys.exit(0 if 'type-check' in json.load(sys.stdin) else 1)" 2>/dev/null; then
     CMD_TYPECHECK="$PKG_MANAGER run type-check"
   elif [ "$HAS_TSCONFIG" = true ]; then
-    CMD_TYPECHECK="npx tsc --noEmit"
+    CMD_TYPECHECK="$EXEC tsc --noEmit"
   fi
 
   # Detect lint command
   if echo "$SCRIPTS_JSON" | python3 -c "import json,sys; sys.exit(0 if 'lint' in json.load(sys.stdin) else 1)" 2>/dev/null; then
     CMD_LINT="$PKG_MANAGER run lint"
   elif [ -f "$PROJECT_DIR/.eslintrc.json" ] || [ -f "$PROJECT_DIR/.eslintrc.js" ] || [ -f "$PROJECT_DIR/.eslintrc.yml" ] || [ -f "$PROJECT_DIR/.eslintrc.yaml" ] || [ -f "$PROJECT_DIR/eslint.config.js" ] || [ -f "$PROJECT_DIR/eslint.config.mjs" ] || [ -f "$PROJECT_DIR/eslint.config.ts" ]; then
-    CMD_LINT="npx eslint ."
+    CMD_LINT="$EXEC eslint ."
   fi
 
   # Detect test command
   if echo "$SCRIPTS_JSON" | python3 -c "import json,sys; sys.exit(0 if 'test' in json.load(sys.stdin) else 1)" 2>/dev/null; then
     CMD_TEST="$PKG_MANAGER run test"
   elif [ -f "$PROJECT_DIR/jest.config.js" ] || [ -f "$PROJECT_DIR/jest.config.ts" ] || [ -f "$PROJECT_DIR/jest.config.mjs" ]; then
-    CMD_TEST="npx jest"
+    CMD_TEST="$EXEC jest"
   elif [ -f "$PROJECT_DIR/vitest.config.js" ] || [ -f "$PROJECT_DIR/vitest.config.ts" ] || [ -f "$PROJECT_DIR/vitest.config.mjs" ]; then
-    CMD_TEST="npx vitest run"
+    CMD_TEST="$EXEC vitest run"
   fi
 fi
 

--- a/tests/git-hook-checks.bats
+++ b/tests/git-hook-checks.bats
@@ -3,6 +3,7 @@
 # ABOUTME: Tests commit-message, branch-protection, progress-md, and test-tiers checks
 
 CHECKS_DIR="$BATS_TEST_DIRNAME/../hooks/git/checks"
+LIB_DIR="$BATS_TEST_DIRNAME/../hooks/git/lib"
 
 setup() {
     TMPDIR="$(mktemp -d)"
@@ -418,4 +419,59 @@ teardown() {
     [ "$status" -eq 0 ]
     # No CodeRabbit output expected — would only appear if CR CLI is installed and finds issues
     [[ "$output" != *"CodeRabbit Advisory"* ]]
+}
+
+@test "pre-push-verify: uses REMOTE_NAME arg to derive diff base when remote is not origin" {
+    BARE_REPO="$TMPDIR/bare"
+    git init --bare "$BARE_REPO" --quiet
+
+    # Add a .only violation to main (simulates existing violation on the base branch)
+    mkdir -p "$GIT_REPO/tests"
+    echo "it.only('focused test', () => {});" > "$GIT_REPO/tests/base.test.js"
+    git -C "$GIT_REPO" add tests/base.test.js
+    git -C "$GIT_REPO" commit -m "add base test" --quiet
+
+    # Push to 'upstream' without -u (no tracking ref, no origin remote)
+    git -C "$GIT_REPO" remote add upstream "file://$BARE_REPO"
+    git -C "$GIT_REPO" push upstream main --quiet
+
+    git -C "$GIT_REPO" checkout -b feature/upstream-docs --quiet
+    echo "# docs" > "$GIT_REPO/guide.md"
+    git -C "$GIT_REPO" add guide.md
+    git -C "$GIT_REPO" commit -m "add guide" --quiet
+
+    # Before fix: DIFF_BASE="" (no tracking ref, no origin/main) → repo-scoped security
+    #             → finds .only in base commit → exits 1
+    # After fix: DIFF_BASE="upstream/main" (derived from REMOTE_NAME + stdin ref)
+    #            → docs-only branch → exits 0
+    run bash -c "cd \"$GIT_REPO\" && printf 'refs/heads/feature/upstream-docs abc123 refs/heads/main abc123\n' | \"$CHECKS_DIR/pre-push-verify.sh\" upstream file://$BARE_REPO 2>&1"
+    [ "$status" -eq 0 ]
+}
+
+# ── detect-project.sh ─────────────────────────────────────────────────────────
+
+@test "detect-project: yarn classic project uses yarn for fallback typecheck command" {
+    PROJ="$TMPDIR/yarn-classic"
+    mkdir "$PROJ"
+    echo '{"name": "test", "scripts": {}}' > "$PROJ/package.json"
+    echo '{}' > "$PROJ/tsconfig.json"
+    touch "$PROJ/yarn.lock"
+    # No .yarnrc.yml = classic Yarn
+
+    run "$LIB_DIR/detect-project.sh" "$PROJ"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"typecheck": "yarn tsc --noEmit"'* ]]
+}
+
+@test "detect-project: yarn berry project uses yarn dlx for fallback typecheck command" {
+    PROJ="$TMPDIR/yarn-berry"
+    mkdir "$PROJ"
+    echo '{"name": "test", "scripts": {}}' > "$PROJ/package.json"
+    echo '{}' > "$PROJ/tsconfig.json"
+    touch "$PROJ/yarn.lock"
+    touch "$PROJ/.yarnrc.yml"  # presence of .yarnrc.yml = Berry/PnP
+
+    run "$LIB_DIR/detect-project.sh" "$PROJ"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"typecheck": "yarn dlx tsc --noEmit"'* ]]
 }


### PR DESCRIPTION
## Summary

- **#68 — pre-push-verify**: Read the git pre-push stdin payload at script start to derive `BRANCH` and `DIFF_BASE` from the actual refs being pushed, rather than from local checkout state and hardcoded `origin` refs. Also replaces hardcoded `origin` with `$REMOTE_NAME` for `REVIEW_BASE`. Fixes edge cases: detached HEAD, non-origin remotes, multi-ref pushes.
- **#69 — detect-project**: Add an `EXEC` variable mapped from the detected package manager so fallback commands (tsc, eslint, jest, vitest) use the correct executor. Yarn classic → `yarn`, Yarn Berry → `yarn dlx`, npm/pnpm → `npx`.

Closes #68
Closes #69

## Test plan

- [ ] 44/44 bats tests pass (`bats tests/git-hook-checks.bats`)
- [ ] New test: docs-only push to non-origin remote exits 0 (regression for #68)
- [ ] New tests: yarn classic and yarn berry fallback commands use correct executor (regression for #69)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-push verification now correctly handles pushing to non-standard Git remotes and properly derives comparison baselines.
  * Improved package manager detection to correctly support different Yarn installation and execution environments.
  * Code review scope now aligns with the actual push remote configuration.

* **Tests**
  * Expanded test coverage for non-standard remote and package manager detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->