### PR TITLE
feat(prd-done): add pre-PR verification agent step

### DIFF
--- a/.claude/skills/prd-done/SKILL.md
+++ b/.claude/skills/prd-done/SKILL.md
@@ -54,6 +54,21 @@ Complete the PRD implementation workflow including branch management, pull reque
 - [ ] **Clean commit history**: Squash or organize commits for clear history
 - [ ] **Push to remote**: `git push -u origin feature/prd-[issue-id]-[feature-name]`
 
+### 2.5. Pre-PR Verification
+
+- [ ] **Launch verification agent** with the following task:
+
+  > Read the full PRD document from top to bottom — all milestones, objectives, and acceptance criteria. For each milestone:
+  >
+  > 1. List every success criterion or objective stated for that milestone.
+  > 2. For each criterion, locate observable evidence in the codebase: the specific file that exists, the function that is wired to the main code path, the test that covers it.
+  > 3. Apply the three-level check — **Exists** (artifact is present) → **Substantive** (real content, not a stub or placeholder) → **Wired** (connected and reachable from the running system).
+  > 4. If any level fails, mark the criterion as a gap.
+  >
+  > Report a criterion-by-criterion table: one row per criterion, with a column for the evidence found. Rows with no evidence must say "GAP — no evidence found" with a specific description of what is missing. Do not summarize at a milestone level. Every criterion must map to a specific, observable artifact.
+
+- [ ] **Surface gaps to the user**: Present the verification report. If any gaps are found, stop and ask the user how to proceed before creating the PR. If no gaps, proceed to Step 3.
+
 ### 3. Pull Request Creation
 
 **IMPORTANT: Always check for and use PR template if available**

--- a/.claude/skills/prd-done/SKILL.v1-yolo.md
+++ b/.claude/skills/prd-done/SKILL.v1-yolo.md
@@ -54,6 +54,21 @@ Complete the PRD implementation workflow including branch management, pull reque
 - [ ] **Clean commit history**: Squash or organize commits for clear history
 - [ ] **Push to remote**: `git push -u origin feature/prd-[issue-id]-[feature-name]`
 
+### 2.5. Pre-PR Verification
+
+- [ ] **Launch verification agent** with the following task:
+
+  > Read the full PRD document from top to bottom — all milestones, objectives, and acceptance criteria. For each milestone:
+  >
+  > 1. List every success criterion or objective stated for that milestone.
+  > 2. For each criterion, locate observable evidence in the codebase: the specific file that exists, the function that is wired to the main code path, the test that covers it.
+  > 3. Apply the three-level check — **Exists** (artifact is present) → **Substantive** (real content, not a stub or placeholder) → **Wired** (connected and reachable from the running system).
+  > 4. If any level fails, mark the criterion as a gap.
+  >
+  > Report a criterion-by-criterion table: one row per criterion, with a column for the evidence found. Rows with no evidence must say "GAP — no evidence found" with a specific description of what is missing. Do not summarize at a milestone level. Every criterion must map to a specific, observable artifact.
+
+- [ ] **Evaluate gaps**: If the agent reports any gaps, implement the missing work and re-run the verification agent before proceeding. If no gaps, proceed to Step 3.
+
 ### 3. Pull Request Creation
 
 **IMPORTANT: Always check for and use PR template if available**


### PR DESCRIPTION
## Summary

- Adds a new **Step 2.5: Pre-PR Verification** to both `SKILL.md` and `SKILL.v1-yolo.md` in the `prd-done` skill
- Before creating a PR, a verification agent reads the full PRD and maps every milestone success criterion to observable codebase evidence using the three-level check: **Exists → Substantive → Wired**
- The agent reports a criterion-by-criterion table; gaps block PR creation until addressed
- YOLO mode auto-implements missing work and re-runs the agent; careful mode surfaces gaps to the user

## Test plan

- [ ] Verify Step 2.5 appears between Step 2 (commit/push) and Step 3 (PR creation) in both skill files
- [ ] Confirm the agent task prompt specifies explicit criterion-to-evidence mapping (no vague "does this seem complete?" checks)
- [ ] Confirm the output format requires a specific artifact for each criterion, not a milestone-level summary
- [ ] Confirm the YOLO and careful variants handle gaps differently (auto-fix vs. surface to user)

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a pre-verification step to the code implementation workflow that validates implementation completeness against requirements before pull requests are created, including a detailed evidence report and gap identification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->