### PR TITLE
fix(hooks): check all three CodeRabbit channels before allowing PR merge

### DIFF
--- a/.claude/skills/verify/scripts/check-coderabbit-required.sh
+++ b/.claude/skills/verify/scripts/check-coderabbit-required.sh
@@ -133,9 +133,17 @@ fi
 # Check for CodeRabbit review via all three GitHub API channels.
 # CodeRabbit posts to different channels depending on PR size and timing;
 # missing any one channel means missing findings.
-CODERABBIT_PULL_REVIEWS=$(gh api "repos/$REPO_INFO/pulls/$PR_NUMBER/reviews" --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' 2>/dev/null || echo "0")
-CODERABBIT_INLINE_COMMENTS=$(gh api "repos/$REPO_INFO/pulls/$PR_NUMBER/comments" --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' 2>/dev/null || echo "0")
-CODERABBIT_ISSUE_COMMENTS=$(gh api "repos/$REPO_INFO/issues/$PR_NUMBER/comments" --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' 2>/dev/null || echo "0")
+# --paginate fetches all pages; jq outputs one line per match; wc -l gives total count.
+count_coderabbit_in_channel() {
+  local endpoint="$1"
+  gh api --paginate "repos/$REPO_INFO/$endpoint" \
+    --jq '.[] | select(.user.login == "coderabbitai[bot]") | 1' 2>/dev/null \
+    | wc -l | tr -d ' ' || echo "0"
+}
+
+CODERABBIT_PULL_REVIEWS=$(count_coderabbit_in_channel "pulls/$PR_NUMBER/reviews")
+CODERABBIT_INLINE_COMMENTS=$(count_coderabbit_in_channel "pulls/$PR_NUMBER/comments")
+CODERABBIT_ISSUE_COMMENTS=$(count_coderabbit_in_channel "issues/$PR_NUMBER/comments")
 
 if [ "$CODERABBIT_PULL_REVIEWS" -gt 0 ] || [ "$CODERABBIT_INLINE_COMMENTS" -gt 0 ] || [ "$CODERABBIT_ISSUE_COMMENTS" -gt 0 ]; then
   # CodeRabbit has reviewed — allow merge

--- a/.claude/skills/verify/scripts/check-coderabbit-required.sh
+++ b/.claude/skills/verify/scripts/check-coderabbit-required.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# ABOUTME: PreToolUse hook that blocks gh pr merge unless a CodeRabbit review exists on the PR.
+# ABOUTME: Checks all three CodeRabbit channels: pull reviews, inline comments, and issue comments.
 # check-coderabbit-required.sh — PreToolUse hook that blocks PR merge without CodeRabbit review
 #
 # Installed as a Claude Code PreToolUse hook on Bash.
@@ -128,10 +130,14 @@ print(json.dumps(result))
   exit 0
 fi
 
-# Check for CodeRabbit review via GitHub API
-CODERABBIT_REVIEW=$(gh api "repos/$REPO_INFO/pulls/$PR_NUMBER/reviews" --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' 2>/dev/null || echo "0")
+# Check for CodeRabbit review via all three GitHub API channels.
+# CodeRabbit posts to different channels depending on PR size and timing;
+# missing any one channel means missing findings.
+CODERABBIT_PULL_REVIEWS=$(gh api "repos/$REPO_INFO/pulls/$PR_NUMBER/reviews" --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' 2>/dev/null || echo "0")
+CODERABBIT_INLINE_COMMENTS=$(gh api "repos/$REPO_INFO/pulls/$PR_NUMBER/comments" --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' 2>/dev/null || echo "0")
+CODERABBIT_ISSUE_COMMENTS=$(gh api "repos/$REPO_INFO/issues/$PR_NUMBER/comments" --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' 2>/dev/null || echo "0")
 
-if [ "$CODERABBIT_REVIEW" -gt 0 ] 2>/dev/null; then
+if [ "$CODERABBIT_PULL_REVIEWS" -gt 0 ] || [ "$CODERABBIT_INLINE_COMMENTS" -gt 0 ] || [ "$CODERABBIT_ISSUE_COMMENTS" -gt 0 ]; then
   # CodeRabbit has reviewed — allow merge
   exit 0
 fi

--- a/tests/check-coderabbit-required.bats
+++ b/tests/check-coderabbit-required.bats
@@ -27,12 +27,14 @@ make_fake_gh() {
     local issue_comments="${3:-0}"
     cat > "$TMPDIR/bin/gh" <<GHEOF
 #!/usr/bin/env bash
+# Output one line per match so wc -l gives the correct count (matching --paginate behavior)
+emit_lines() { local n="\$1"; for i in \$(seq 1 "\$n" 2>/dev/null); do echo 1; done; }
 if [[ "\$*" == *"pulls/42/reviews"* ]]; then
-    echo "$pull_reviews"
+    emit_lines "$pull_reviews"
 elif [[ "\$*" == *"pulls/42/comments"* ]]; then
-    echo "$inline_comments"
+    emit_lines "$inline_comments"
 elif [[ "\$*" == *"issues/42/comments"* ]]; then
-    echo "$issue_comments"
+    emit_lines "$issue_comments"
 fi
 GHEOF
     chmod +x "$TMPDIR/bin/gh"

--- a/tests/check-coderabbit-required.bats
+++ b/tests/check-coderabbit-required.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# ABOUTME: Tests for check-coderabbit-required.sh — verifies all three CodeRabbit channels are checked.
+# ABOUTME: Uses a fake gh binary to simulate different review configurations without real API calls.
+
+SCRIPT="$BATS_TEST_DIRNAME/../.claude/skills/verify/scripts/check-coderabbit-required.sh"
+
+setup() {
+    TMPDIR="$(mktemp -d)"
+    mkdir -p "$TMPDIR/bin"
+    chmod +x "$SCRIPT" 2>/dev/null || true
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+# Write a JSON hook payload to $TMPDIR/input.json
+write_input() {
+    printf '%s' "$1" > "$TMPDIR/input.json"
+}
+
+# Create a fake gh binary with specified review counts per channel.
+# Args: pull_reviews inline_comments issue_comments
+make_fake_gh() {
+    local pull_reviews="${1:-0}"
+    local inline_comments="${2:-0}"
+    local issue_comments="${3:-0}"
+    cat > "$TMPDIR/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"pulls/42/reviews"* ]]; then
+    echo "$pull_reviews"
+elif [[ "\$*" == *"pulls/42/comments"* ]]; then
+    echo "$inline_comments"
+elif [[ "\$*" == *"issues/42/comments"* ]]; then
+    echo "$issue_comments"
+fi
+GHEOF
+    chmod +x "$TMPDIR/bin/gh"
+}
+
+# Merge command using --repo to skip git-remote detection
+MERGE_CMD='gh pr merge 42 --merge --delete-branch --repo testowner/testrepo'
+
+# ── Allow cases: hook should pass through silently ────────────────────────────
+
+@test "allows merge when review is in pull reviews channel only" {
+    make_fake_gh 1 0 0
+    write_input "{\"tool_input\":{\"command\":\"$MERGE_CMD\"},\"cwd\":\"/tmp\"}"
+    run bash -c "PATH=\"$TMPDIR/bin:\$PATH\" \"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "allows merge when review is only in inline comments channel" {
+    make_fake_gh 0 1 0
+    write_input "{\"tool_input\":{\"command\":\"$MERGE_CMD\"},\"cwd\":\"/tmp\"}"
+    run bash -c "PATH=\"$TMPDIR/bin:\$PATH\" \"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "allows merge when review is only in issue comments channel (the previously-broken case)" {
+    make_fake_gh 0 0 1
+    write_input "{\"tool_input\":{\"command\":\"$MERGE_CMD\"},\"cwd\":\"/tmp\"}"
+    run bash -c "PATH=\"$TMPDIR/bin:\$PATH\" \"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ── Block case: no review in any channel ──────────────────────────────────────
+
+@test "blocks merge when no CodeRabbit review in any channel" {
+    make_fake_gh 0 0 0
+    write_input "{\"tool_input\":{\"command\":\"$MERGE_CMD\"},\"cwd\":\"/tmp\"}"
+    run bash -c "PATH=\"$TMPDIR/bin:\$PATH\" \"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['hookSpecificOutput']['permissionDecision']=='deny'"
+    [[ "$output" == *"CodeRabbit review is required"* ]]
+}
+
+# ── Passthrough: non-merge commands ──────────────────────────────────────────
+
+@test "passes through non-merge gh commands silently" {
+    make_fake_gh 0 0 0
+    write_input '{"tool_input":{"command":"gh pr list"},"cwd":"/tmp"}'
+    run bash -c "PATH=\"$TMPDIR/bin:\$PATH\" \"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "passes through non-gh commands silently" {
+    make_fake_gh 0 0 0
+    write_input '{"tool_input":{"command":"git status"},"cwd":"/tmp"}'
+    run bash -c "PATH=\"$TMPDIR/bin:\$PATH\" \"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

- `check-coderabbit-required.sh` previously only checked `/pulls/{n}/reviews` for CodeRabbit activity
- CodeRabbit posts to three channels: pull reviews, inline comments, and issue comments — the hook was missing the other two
- When CodeRabbit's summary landed in issue comments (as with PR #74), the hook blocked the merge with a false "No CodeRabbit review found" error
- Now checks all three channels; allows merge if any has a `coderabbitai[bot]` comment
- Adds ABOUTME headers (were missing) and a 6-test bats suite covering all three allow channels, the block case, and non-merge passthrough

## Test plan

- [ ] `bats tests/check-coderabbit-required.bats` — 6/6 pass
- [ ] Test 3 ("allows merge when review is only in issue comments channel") specifically covers the previously-broken case

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CodeRabbit review detection by checking PR reviews, PR comments, and issue comments so merges succeed when any channel shows a valid review.

* **Tests**
  * Added tests covering all verification channels, deny behavior when none are present, and passthrough behavior for non-merge commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->