### PR TITLE
Add handoff readiness check and PROGRESS/ROADMAP rules

### DIFF
--- a/.claude/skills/prd-update-progress/SKILL.md
+++ b/.claude/skills/prd-update-progress/SKILL.md
@@ -337,6 +337,20 @@ If `coderabbit` is not installed, skip this step with a note: "CodeRabbit CLI no
 
 If this work is part of a PRD, assess whether any design decisions emerged during this implementation session — architecture changes, scope adjustments, technical discoveries, or approach pivots. If any did, run `/prd-update-decisions` to capture them before moving on. This ensures decisions are recorded and propagated to downstream milestones while context is fresh.
 
+## Step 8.9: Handoff Readiness Check
+
+Before suggesting `/clear`, answer honestly: **will the next AI instance have everything it needs to pick up where this session left off?**
+
+Walk through these explicitly — don't answer reflexively:
+
+- **Decisions** — are non-obvious choices (pivots, rejected alternatives, constraints discovered) captured in the PRD or a comment? If they live only in this conversation, write them down now.
+- **PROGRESS.md** — if this repo has one, does it reflect today's changes?
+- **Open questions** — is anything you paused on or deferred captured in the PRD, a code TODO, or a GitHub issue?
+- **Next task's entry point** — is the next PRD task concretely described, or does it rely on context only you currently hold? If the latter, add the missing context to the PRD.
+- **Workarounds and gotchas** — did you discover something non-obvious (a failed approach, a tooling quirk) that the next instance would re-learn the hard way? Document it in the PRD, a rule file, or a code comment.
+
+If any answer is "no," fix it before the next-steps summary. Only suggest `/clear` when the answer is genuinely yes.
+
 ## Step 9: Next Steps Based on PRD Status
 
 After completing the PRD update, committing changes, and addressing any CodeRabbit findings, guide the user based on completion status:

--- a/.claude/skills/prd-update-progress/SKILL.v1-yolo.md
+++ b/.claude/skills/prd-update-progress/SKILL.v1-yolo.md
@@ -330,6 +330,20 @@ If `coderabbit` is not installed, skip this step with a note: "CodeRabbit CLI no
 
 If this work is part of a PRD, assess whether any design decisions emerged during this implementation session — architecture changes, scope adjustments, technical discoveries, or approach pivots. If any did, run `/prd-update-decisions` to capture them before moving on. This ensures decisions are recorded and propagated to downstream milestones while context is fresh.
 
+## Step 8.9: Handoff Readiness Check
+
+Before suggesting `/clear`, answer honestly: **will the next AI instance have everything it needs to pick up where this session left off?**
+
+Walk through these explicitly — don't answer reflexively:
+
+- **Decisions** — are non-obvious choices (pivots, rejected alternatives, constraints discovered) captured in the PRD or a comment? If they live only in this conversation, write them down now.
+- **PROGRESS.md** — if this repo has one, does it reflect today's changes?
+- **Open questions** — is anything you paused on or deferred captured in the PRD, a code TODO, or a GitHub issue?
+- **Next task's entry point** — is the next PRD task concretely described, or does it rely on context only you currently hold? If the latter, add the missing context to the PRD.
+- **Workarounds and gotchas** — did you discover something non-obvious (a failed approach, a tooling quirk) that the next instance would re-learn the hard way? Document it in the PRD, a rule file, or a code comment.
+
+If any answer is "no," fix it before the next-steps summary. Only suggest `/clear` when the answer is genuinely yes.
+
 ## Step 9: Next Steps Based on PRD Status
 
 After completing the PRD update, committing changes, and addressing any CodeRabbit findings, present a brief summary:

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -30,7 +30,7 @@ When drafting emails or written communication:
 - **You MUST ask permission** before reimplementing features or systems from scratch.
 - Prefer deterministic scripts/code over AI for operational tasks. Use AI for content understanding, narrative synthesis, and semantic analysis.
 - When creating prompts for AI agents, emphasize the process to follow rather than stating the goal upfront.
-- When creating or modifying any SKILL.md file, system prompt, or AI agent instruction, use `/write-prompt` to review the result before committing.
+- When creating or modifying any SKILL.md file, system prompt, AI agent instruction, or PRD, use `/write-prompt` to review the result before committing. PRDs are prompts — future agents read and act on them.
 - **ALWAYS add progress indicators** for any operation that might cause the user to wait. This includes downloading files, processing large datasets, network requests, and any computation that takes more than 1-2 seconds.
 - **MANDATORY**: When writing user-facing documentation (README, guides, PRD milestones), invoke `/write-docs`. Do not skip this step. Excludes CLAUDE.md and rule files.
 
@@ -75,6 +75,28 @@ When you have multiple questions or decisions for the user, present them **one a
 ## GitHub Issues
 
 When creating a GitHub issue: draft the body, then use the Skill tool to invoke `/write-prompt` passing the draft as input — ask it to organize the unstructured content into a clear, polished version without adding, removing, or changing meaning. Use the polished result when calling `gh issue create`.
+
+Every GitHub issue body must end with a checklist item that updates the project's `PROGRESS.md` (style rules below). Without this, non-PRD work accumulates without a durable record.
+
+## PROGRESS.md
+
+When a repo has a `PROGRESS.md` at its root, write entries in this style:
+
+- **Format**: `- (YYYY-MM-DD) [Prose description of what changed and why].` under the appropriate section heading (Added, Changed, Deprecated, Removed, Fixed, Security).
+- **Convention**: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are for external readers of the repo, not internal workflow tracking.
+- **Include**: what changed, why, and the reasoning behind the decision. User-facing identifiers (rule IDs, API names, paths like `docs/rules-reference.md`) are fine — but **briefly explain each on first use**, e.g., "CDQ-007 (PII attribute names, filesystem paths, nullable access)" rather than bare "CDQ-007".
+- **Omit**: GitHub issue numbers, PRD numbers, milestone IDs ("M1", "B3"), test counts, internal file paths, commit SHAs. The closing commit handles ticket linkage.
+
+Narrative issue references in prose ("Closed issue #493 as working as intended") are fine — that's context, not metadata. Avoid trailing `Closes #NNN.` lines; those belong in commit messages.
+
+## ROADMAP.md
+
+When a repo has a `docs/ROADMAP.md`, update it on PRD lifecycle events:
+
+- **On PRD creation**: add an entry to the appropriate timeframe tier (Short-term / Medium-term / Long-term by PRD priority): `- [Brief description] ([PRD #NNN](issue-url)) — [1-line rationale or blocked-by]`. If a placeholder exists ("new PRD, to be created"), update in place — don't duplicate.
+- **On PRD closure**: remove the entry. ROADMAP is forward-looking; completed work lives in `PROGRESS.md`.
+
+Link to the GitHub issue, not the PRD file path — issues are stable across renames.
 
 ## Issue Juggling
 


### PR DESCRIPTION
## Summary

- **`prd-update-progress` (careful + yolo):** Add Step 8.9 Handoff Readiness Check before suggesting `/clear`. Prompts the implementing agent to verify decisions, `PROGRESS.md`, open questions, next-task context, and workarounds/gotchas are documented before context is wiped.
- **Global `CLAUDE.md`:** Add `## PROGRESS.md` style rules and `## ROADMAP.md` lifecycle rules; extend `/write-prompt` trigger list to cover PRDs.

Motivation: the implementing agent often says "run `/clear` and `/prd-next`" when the next instance would actually be missing context (decisions made in conversation, undocumented gotchas, next task that relies on session-local knowledge). The new Step 8.9 makes the agent explicitly walk through a checklist before handing off.

Wording in the new CLAUDE.md sections tightened via `/write-prompt` review before pushing.

## Test plan

- [ ] Run `/prd-update-progress` on a real PRD task and confirm Step 8.9 fires before the next-steps summary
- [ ] Confirm the checklist items (decisions, PROGRESS.md, open questions, next task entry point, workarounds/gotchas) produce useful prompts in practice
- [ ] Verify both careful and yolo SKILL.md variants trigger the check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a handoff readiness validation checklist to ensure decisions, progress tracking, open questions, task entry points, and workarounds are documented before proceeding.
  * Introduced new process requirements for issue workflows and updated documentation conventions for progress tracking and roadmap management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->