### PR TITLE
feat(hooks): add post-merge branch cleanup reminder hook

### DIFF
--- a/.claude/skills/verify/scripts/suggest-branch-cleanup.sh
+++ b/.claude/skills/verify/scripts/suggest-branch-cleanup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ABOUTME: PostToolUse hook — reminds Claude to delete branches and close linked issues after gh pr merge.
-# ABOUTME: Fires on Bash tool calls containing "gh pr merge". Advisory only (exit 0 always).
+# ABOUTME: Fires only on successful Bash tool calls that invoke gh pr merge. Advisory only (exit 0 always).
 
 set -uo pipefail
 
@@ -16,7 +16,14 @@ import json, sys, re
 data = json.load(sys.stdin)
 command = data.get('tool_input', {}).get('command', '')
 
-if not re.search(r'(^|\s|&&\s*|;\s*)gh\s+pr\s+merge\b', command):
+# Require gh pr merge at string start or immediately after a shell command separator.
+# Using ^\s* / &&\s* / ||\s* / ;\s* avoids false positives from 'echo gh pr merge' etc.
+if not re.search(r'(^\s*|&&\s*|\|\|\s*|;\s*)gh\s+pr\s+merge\b', command):
+    sys.exit(0)
+
+# Only fire if the merge succeeded — tool_response contains the success message.
+response = str(data.get('tool_response', ''))
+if 'merged' not in response.lower():
     sys.exit(0)
 
 msg = (

--- a/.claude/skills/verify/scripts/suggest-branch-cleanup.sh
+++ b/.claude/skills/verify/scripts/suggest-branch-cleanup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# ABOUTME: PostToolUse hook — reminds Claude to delete branches and close linked issues after gh pr merge.
+# ABOUTME: Fires on Bash tool calls containing "gh pr merge". Advisory only (exit 0 always).
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || echo "")
+
+[[ "$TOOL_NAME" != "Bash" ]] && exit 0
+
+python3 -c "
+import json, sys, re
+
+data = json.load(sys.stdin)
+command = data.get('tool_input', {}).get('command', '')
+
+if not re.search(r'(^|\s|&&\s*|;\s*)gh\s+pr\s+merge\b', command):
+    sys.exit(0)
+
+msg = (
+    'Post-merge cleanup: Delete the feature branch locally and from the remote. '
+    'Also confirm the linked GitHub issue was closed — either auto-closed via '
+    'a Closes #NNN line in the PR, or close it manually now.'
+)
+print(json.dumps({
+    'hookSpecificOutput': {
+        'hookEventName': 'PostToolUse',
+        'additionalContext': msg
+    }
+}))
+" <<< "$INPUT" 2>/dev/null || true
+
+exit 0

--- a/.claude/skills/verify/scripts/suggest-branch-cleanup.sh
+++ b/.claude/skills/verify/scripts/suggest-branch-cleanup.sh
@@ -21,9 +21,11 @@ command = data.get('tool_input', {}).get('command', '')
 if not re.search(r'(^\s*|&&\s*|\|\|\s*|;\s*)gh\s+pr\s+merge\b', command):
     sys.exit(0)
 
-# Only fire if the merge succeeded — tool_response contains the success message.
+# Only fire if the merge succeeded — check tool_response for the gh success phrase.
+# Matching 'merged pull request' avoids false positives from failure messages
+# like 'was not merged' that also contain the word 'merged'.
 response = str(data.get('tool_response', ''))
-if 'merged' not in response.lower():
+if 'merged pull request' not in response.lower():
     sys.exit(0)
 
 msg = (

--- a/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
+++ b/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
@@ -1,0 +1,87 @@
+# ABOUTME: Tests for suggest-branch-cleanup.sh PostToolUse hook.
+# ABOUTME: Verifies advisory fires on gh pr merge commands, silent for all other Bash calls.
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from test_harness import TestResults, hook_path, run_hook
+
+HOOK = hook_path("suggest-branch-cleanup.sh")
+
+
+def make_bash_input(command: str) -> str:
+    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+
+
+def make_other_tool_input(tool_name: str) -> str:
+    return json.dumps({"tool_name": tool_name, "tool_input": {}})
+
+
+def has_advisory(stdout: str) -> bool:
+    if not stdout.strip():
+        return False
+    try:
+        data = json.loads(stdout)
+        ctx = data.get("hookSpecificOutput", {}).get("additionalContext", "").lower()
+        return "branch" in ctx and "issue" in ctx
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+
+def run_tests():
+    t = TestResults("suggest-branch-cleanup")
+    t.header()
+
+    t.section("gh pr merge commands — advisory emitted")
+
+    exit_code, stdout = run_hook(HOOK, make_bash_input("gh pr merge 42 --merge"))
+    t.assert_equal("basic gh pr merge exits 0", exit_code, 0)
+    t.assert_equal("basic gh pr merge emits advisory", has_advisory(stdout), True)
+
+    exit_code, stdout = run_hook(HOOK, make_bash_input("gh pr merge --squash"))
+    t.assert_equal("gh pr merge --squash exits 0", exit_code, 0)
+    t.assert_equal("gh pr merge --squash emits advisory", has_advisory(stdout), True)
+
+    exit_code, stdout = run_hook(HOOK, make_bash_input("cd myrepo && gh pr merge 10 --rebase"))
+    t.assert_equal("chained gh pr merge exits 0", exit_code, 0)
+    t.assert_equal("chained gh pr merge emits advisory", has_advisory(stdout), True)
+
+    t.section("Other Bash commands — silent")
+
+    for command in [
+        "gh pr create --title 'foo'",
+        "gh pr list",
+        "gh pr view 42",
+        "git merge feature/foo",
+        "git push origin --delete feature/my-branch",
+        "echo 'gh pr merge'",
+    ]:
+        exit_code, stdout = run_hook(HOOK, make_bash_input(command))
+        t.assert_equal(f"'{command}' exits 0", exit_code, 0)
+        t.assert_equal(f"'{command}' produces no advisory", has_advisory(stdout), False)
+
+    t.section("Non-Bash tools — silent")
+
+    for tool in ["Write", "Edit", "Read"]:
+        exit_code, stdout = run_hook(HOOK, make_other_tool_input(tool))
+        t.assert_equal(f"{tool} tool exits 0", exit_code, 0)
+        t.assert_equal(f"{tool} tool produces no advisory", stdout.strip(), "")
+
+    t.section("Edge cases")
+
+    exit_code, stdout = run_hook(HOOK, "{invalid json}")
+    t.assert_equal("invalid JSON exits 0", exit_code, 0)
+
+    exit_code, stdout = run_hook(HOOK, make_bash_input(""))
+    t.assert_equal("empty command exits 0", exit_code, 0)
+    t.assert_equal("empty command produces no advisory", has_advisory(stdout), False)
+
+    t.summary()
+    return t.failed == 0
+
+
+if __name__ == "__main__":
+    success = run_tests()
+    sys.exit(0 if success else 1)

--- a/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
+++ b/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
@@ -10,7 +10,7 @@ from test_harness import TestResults, hook_path, make_hook_input, run_hook
 
 HOOK = hook_path("suggest-branch-cleanup.sh")
 
-SUCCESS_RESPONSE = "✓ Merged pull request #42 (title)\n"
+SUCCESS_RESPONSE = "Merged pull request #42 (title)\n"
 FAILURE_RESPONSE = "error: pull request is not mergeable"
 
 
@@ -58,6 +58,10 @@ def run_tests():
     exit_code, stdout = run_hook(HOOK, make_merge_input("gh pr merge 42", FAILURE_RESPONSE))
     t.assert_equal("failed merge exits 0", exit_code, 0)
     t.assert_equal("failed merge produces no advisory", has_advisory(stdout), False)
+
+    exit_code, stdout = run_hook(HOOK, make_merge_input("gh pr merge 42", "error: pull request was not merged"))
+    t.assert_equal("'was not merged' response exits 0", exit_code, 0)
+    t.assert_equal("'was not merged' response produces no advisory", has_advisory(stdout), False)
 
     exit_code, stdout = run_hook(HOOK, make_hook_input("gh pr merge 42"))
     t.assert_equal("no tool_response exits 0", exit_code, 0)

--- a/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
+++ b/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
@@ -1,18 +1,23 @@
 # ABOUTME: Tests for suggest-branch-cleanup.sh PostToolUse hook.
-# ABOUTME: Verifies advisory fires on gh pr merge commands, silent for all other Bash calls.
+# ABOUTME: Verifies advisory fires only on successful gh pr merge commands, silent otherwise.
 
 import json
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from test_harness import TestResults, hook_path, run_hook
+from test_harness import TestResults, hook_path, make_hook_input, run_hook
 
 HOOK = hook_path("suggest-branch-cleanup.sh")
 
+SUCCESS_RESPONSE = "✓ Merged pull request #42 (title)\n"
+FAILURE_RESPONSE = "error: pull request is not mergeable"
 
-def make_bash_input(command: str) -> str:
-    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+
+def make_merge_input(command: str, response: str = SUCCESS_RESPONSE) -> str:
+    data = json.loads(make_hook_input(command))
+    data["tool_response"] = response
+    return json.dumps(data)
 
 
 def make_other_tool_input(tool_name: str) -> str:
@@ -34,19 +39,29 @@ def run_tests():
     t = TestResults("suggest-branch-cleanup")
     t.header()
 
-    t.section("gh pr merge commands — advisory emitted")
+    t.section("Successful gh pr merge — advisory emitted")
 
-    exit_code, stdout = run_hook(HOOK, make_bash_input("gh pr merge 42 --merge"))
-    t.assert_equal("basic gh pr merge exits 0", exit_code, 0)
-    t.assert_equal("basic gh pr merge emits advisory", has_advisory(stdout), True)
+    exit_code, stdout = run_hook(HOOK, make_merge_input("gh pr merge 42 --merge"))
+    t.assert_equal("basic merge exits 0", exit_code, 0)
+    t.assert_equal("basic merge emits advisory", has_advisory(stdout), True)
 
-    exit_code, stdout = run_hook(HOOK, make_bash_input("gh pr merge --squash"))
-    t.assert_equal("gh pr merge --squash exits 0", exit_code, 0)
-    t.assert_equal("gh pr merge --squash emits advisory", has_advisory(stdout), True)
+    exit_code, stdout = run_hook(HOOK, make_merge_input("gh pr merge --squash"))
+    t.assert_equal("squash merge exits 0", exit_code, 0)
+    t.assert_equal("squash merge emits advisory", has_advisory(stdout), True)
 
-    exit_code, stdout = run_hook(HOOK, make_bash_input("cd myrepo && gh pr merge 10 --rebase"))
-    t.assert_equal("chained gh pr merge exits 0", exit_code, 0)
-    t.assert_equal("chained gh pr merge emits advisory", has_advisory(stdout), True)
+    exit_code, stdout = run_hook(HOOK, make_merge_input("cd myrepo && gh pr merge 10 --rebase"))
+    t.assert_equal("chained merge exits 0", exit_code, 0)
+    t.assert_equal("chained merge emits advisory", has_advisory(stdout), True)
+
+    t.section("Failed or missing tool_response — silent")
+
+    exit_code, stdout = run_hook(HOOK, make_merge_input("gh pr merge 42", FAILURE_RESPONSE))
+    t.assert_equal("failed merge exits 0", exit_code, 0)
+    t.assert_equal("failed merge produces no advisory", has_advisory(stdout), False)
+
+    exit_code, stdout = run_hook(HOOK, make_hook_input("gh pr merge 42"))
+    t.assert_equal("no tool_response exits 0", exit_code, 0)
+    t.assert_equal("no tool_response produces no advisory", has_advisory(stdout), False)
 
     t.section("Other Bash commands — silent")
 
@@ -56,9 +71,10 @@ def run_tests():
         "gh pr view 42",
         "git merge feature/foo",
         "git push origin --delete feature/my-branch",
+        "echo gh pr merge",
         "echo 'gh pr merge'",
     ]:
-        exit_code, stdout = run_hook(HOOK, make_bash_input(command))
+        exit_code, stdout = run_hook(HOOK, make_hook_input(command))
         t.assert_equal(f"'{command}' exits 0", exit_code, 0)
         t.assert_equal(f"'{command}' produces no advisory", has_advisory(stdout), False)
 
@@ -74,15 +90,13 @@ def run_tests():
     exit_code, stdout = run_hook(HOOK, "{invalid json}")
     t.assert_equal("invalid JSON exits 0", exit_code, 0)
 
-    exit_code, stdout = run_hook(HOOK, make_bash_input(""))
+    exit_code, stdout = run_hook(HOOK, make_hook_input(""))
     t.assert_equal("empty command exits 0", exit_code, 0)
     t.assert_equal("empty command produces no advisory", has_advisory(stdout), False)
 
-    t.summary()
     return t.passed, t.failed, t.passed + t.failed
 
 
 if __name__ == "__main__":
     passed, failed, _ = run_tests()
-    success = failed == 0
-    sys.exit(0 if success else 1)
+    sys.exit(0 if failed == 0 else 1)

--- a/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
+++ b/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
@@ -79,9 +79,10 @@ def run_tests():
     t.assert_equal("empty command produces no advisory", has_advisory(stdout), False)
 
     t.summary()
-    return t.failed == 0
+    return t.passed, t.failed, t.passed + t.failed
 
 
 if __name__ == "__main__":
-    success = run_tests()
+    passed, failed, _ = run_tests()
+    success = failed == 0
     sys.exit(0 if success else 1)

--- a/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
+++ b/.claude/skills/verify/tests/test_suggest_branch_cleanup.py
@@ -93,6 +93,7 @@ def run_tests():
 
     exit_code, stdout = run_hook(HOOK, "{invalid json}")
     t.assert_equal("invalid JSON exits 0", exit_code, 0)
+    t.assert_equal("invalid JSON produces no advisory", stdout.strip(), "")
 
     exit_code, stdout = run_hook(HOOK, make_hook_input(""))
     t.assert_equal("empty command exits 0", exit_code, 0)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,7 +6,7 @@ Development progress log for claude-config. Tracks implementation milestones acr
 
 ### Added
 
-- (2026-04-25) Added a PostToolUse hook (`suggest-branch-cleanup.sh`) that fires after every `gh pr merge` command and injects an advisory reminding Claude to delete the feature branch locally and from the remote, and to confirm the linked GitHub issue was closed — addressing a recurring problem where branches and issues were left open after PRs merged; also added a matching rule to global CLAUDE.md
+- (2026-04-25) Added a post-merge advisory that prompts branch deletion locally and from the remote, and confirmation that any linked GitHub issue is closed — addressing a recurring pattern where merged PRs left follow-up cleanup incomplete; also added several missing technology gotcha references to the global development guide
 
 - (2026-04-24) Made the date command in the `/continue` skill platform-portable — replaced the macOS-only `date -v-1d` with `python3` as the primary fallback (works everywhere), with platform-specific alternatives listed for environments without python3
 - (2026-04-24) Rewrote Step 8.9 in `/prd-update-progress` (both standard and YOLO variants) from a self-assessment checklist to an enforcement-based step — each item is now an action to complete before suggesting `/clear`, not a question to answer; the final line makes the contract explicit: done when all five actions are complete, not when they have been assessed

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,8 @@ Development progress log for claude-config. Tracks implementation milestones acr
 
 ### Added
 
+- (2026-04-25) Added a PostToolUse hook (`suggest-branch-cleanup.sh`) that fires after every `gh pr merge` command and injects an advisory reminding Claude to delete the feature branch locally and from the remote, and to confirm the linked GitHub issue was closed — addressing a recurring problem where branches and issues were left open after PRs merged; also added a matching rule to global CLAUDE.md
+
 - (2026-04-24) Made the date command in the `/continue` skill platform-portable — replaced the macOS-only `date -v-1d` with `python3` as the primary fallback (works everywhere), with platform-specific alternatives listed for environments without python3
 - (2026-04-24) Rewrote Step 8.9 in `/prd-update-progress` (both standard and YOLO variants) from a self-assessment checklist to an enforcement-based step — each item is now an action to complete before suggesting `/clear`, not a question to answer; the final line makes the contract explicit: done when all five actions are complete, not when they have been assessed
 - (2026-04-24) Added `progress-md-pr.sh` pre-push check — blocks pushes on branches with no PROGRESS.md changes vs the base branch; auto-drafts a suggested entry from commit messages, then offers accept/edit/skip via `/dev/tty`; non-interactive environments (CI, no TTY) get an advisory warning and pass; wired into the pre-push dispatcher between test-tiers and pre-push-verify

--- a/config/settings.json
+++ b/config/settings.json
@@ -164,6 +164,10 @@
           {
             "type": "command",
             "command": "/Users/whitney.lee/Documents/Repositories/claude-config/.claude/skills/verify/scripts/suggest-write-prompt.sh"
+          },
+          {
+            "type": "command",
+            "command": "/Users/whitney.lee/Documents/Repositories/claude-config/.claude/skills/verify/scripts/suggest-branch-cleanup.sh"
           }
         ]
       }

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -52,6 +52,8 @@ When you have multiple questions or decisions for the user, present them **one a
 - Weaver (v0.22.1 auto-escaping defaults, definition schema format): @~/.claude/rules/weaver-gotchas.md
 - Micro.blog API (dual auth tokens, editPage param order, feed-based cross-posting): @~/.claude/rules/microblog-api-gotchas.md
 - OTel JS semantic conventions (stable vs incubating entry-points, DB/HTTP attribute renames, deprecated SEMATTRS_*): @~/.claude/rules/otel-semconv-gotchas.md
+- mmdc/mermaid-cli (Puppeteer peer dep, Apple Silicon Chrome path, npx -p flag, PNG scaling): @~/.claude/rules/mmdc-gotchas.md
+- Social platform video upload (Bluesky separate service token, Mastodon async 202 poll, LinkedIn 4-step init/upload/finalize/poll + ETag stripping): @~/.claude/rules/social-video-upload-gotchas.md
 
 ## Testing
 
@@ -70,7 +72,9 @@ When you have multiple questions or decisions for the user, present them **one a
 ## Git Workflow
 
 - Feature branches only. PRs require CodeRabbit review approved by human before merge.
+- After merging a PR, delete the feature branch locally and from the remote.
 - Full workflow, CodeRabbit process, and triage rubric: @~/.claude/rules/git-workflow.md
+- GitHub CLI fork gotchas (gh pr create targets upstream by default): @~/.claude/rules/gh-fork-gotchas.md
 
 ## GitHub Issues
 
@@ -146,6 +150,11 @@ Feature work is tracked in PRDs (`prds/` directory). Use the PRD skills: `/prd-c
 - **Do NOT commit manually during PRD work.** `/prd-update-progress` handles commits, PRD updates, and journaling together.
 - Cross-PRD dependencies block clean merges. Design PRDs so every milestone is completable from main alone. Recovery when one is discovered mid-implementation: @~/.claude/rules/prd-dependency-management.md
 - **Decision cascade**: When a row is added to a PRD's `## Decision Log`, evaluate each remaining milestone in that PRD: does the new decision change its prerequisites, approach, or success criteria? Update any milestone whose plan is affected. Then scan other open PRDs in `prds/` — if the decision is relevant to their scope, open those PRDs and update their affected milestones too.
+
+## Eval Run Setup (spinybacked-orbweaver-eval)
+
+When setting up a new spiny-orb evaluation target or running `spiny-orb instrument`:
+- GitHub PAT setup, dry-run verification, and failure modes: @~/.claude/rules/eval-github-pat.md
 
 ## Conflict Resolution
 

--- a/rules/hooks-reference.md
+++ b/rules/hooks-reference.md
@@ -38,6 +38,7 @@ Install with `bash scripts/install-git-hooks.sh [repo-path]`. The installer is i
 
 - **post-write-codeblock-check.sh** (PostToolUse: Write|Edit) — checks markdown files for bare code blocks missing language specifiers
 - **suggest-write-prompt.sh** (PostToolUse: Write|Edit, Bash) — advisory reminder to run `/write-prompt` when SKILL.md or CLAUDE.md files are edited, or when `gh issue create` succeeds; explains that any AI-consumed document is a prompt
+- **suggest-branch-cleanup.sh** (PostToolUse: Bash) — advisory reminder to delete the feature branch locally and from the remote, and confirm the linked GitHub issue is closed, after `gh pr merge` commands
 - **cascade-decision-check.sh** (PostToolUse: Write|Edit) — advisory reminder to cascade-evaluate downstream milestones when a PRD file in `prds/` is edited; prompts Claude to check for new Decision Log rows and update affected milestones in the current and other open PRDs
 
 ## Supplemental Code Review

--- a/tests/suggest-branch-cleanup.bats
+++ b/tests/suggest-branch-cleanup.bats
@@ -18,7 +18,7 @@ write_input() {
 }
 
 @test "fires advisory for successful gh pr merge" {
-    write_input '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 42 --merge"},"cwd":"/tmp","tool_response":"Merged pull request #42 (title)\n"}'
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 42 --merge"},"cwd":"/tmp","tool_response":"Merged pull request #42 (title)"}'
     run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
     [ "$status" -eq 0 ]
     [[ "$output" == *"additionalContext"* ]]
@@ -27,6 +27,13 @@ write_input() {
 
 @test "silent for failed gh pr merge" {
     write_input '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 42"},"cwd":"/tmp","tool_response":"error: pull request is not mergeable"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent when response contains 'was not merged'" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 42"},"cwd":"/tmp","tool_response":"error: pull request was not merged"}'
     run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
     [ "$status" -eq 0 ]
     [ -z "$output" ]

--- a/tests/suggest-branch-cleanup.bats
+++ b/tests/suggest-branch-cleanup.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# ABOUTME: Tests for suggest-branch-cleanup.sh PostToolUse hook
+# ABOUTME: Verifies advisory fires only on successful gh pr merge; silent otherwise
+
+SCRIPT="$BATS_TEST_DIRNAME/../.claude/skills/verify/scripts/suggest-branch-cleanup.sh"
+
+setup() {
+    TMPDIR="$(mktemp -d)"
+    chmod +x "$SCRIPT" 2>/dev/null || true
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+write_input() {
+    printf '%s' "$1" > "$TMPDIR/input.json"
+}
+
+@test "fires advisory for successful gh pr merge" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 42 --merge"},"cwd":"/tmp","tool_response":"Merged pull request #42 (title)\n"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+    [[ "$output" == *"branch"* ]]
+}
+
+@test "silent for failed gh pr merge" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 42"},"cwd":"/tmp","tool_response":"error: pull request is not mergeable"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent when no tool_response present" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 42"},"cwd":"/tmp"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for gh pr create" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh pr create --title foo"},"cwd":"/tmp"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for echo gh pr merge (not a command invocation)" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"echo gh pr merge"},"cwd":"/tmp"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for non-Bash tool" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/tmp/foo.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "handles invalid JSON without error" {
+    write_input 'not valid json'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+}

--- a/tests/suggest-branch-cleanup.bats
+++ b/tests/suggest-branch-cleanup.bats
@@ -71,4 +71,5 @@ write_input() {
     write_input 'not valid json'
     run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
     [ "$status" -eq 0 ]
+    [ -z "$output" ]
 }


### PR DESCRIPTION
## Description

**What does this PR do?**

Adds a PostToolUse hook (`suggest-branch-cleanup.sh`) that fires after every `gh pr merge` command and injects an advisory reminding Claude to delete the feature branch locally and from the remote, and to confirm the linked GitHub issue was closed. Also updates global CLAUDE.md with the branch deletion rule and references to recently added gotcha rule files (mmdc, social video upload, gh-fork, eval GitHub PAT), and documents the hook in `rules/hooks-reference.md`.

**Why is this change needed?**

Branches and linked issues were repeatedly left open after PRs merged. A hook-based reminder at the exact moment of merge is the right enforcement point — it fires automatically without relying on memory or manual checklists.

## Related Issues

- Closes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [x] ✅ Test updates (adding or updating tests)
- [x] 🔧 Configuration changes
- [ ] 🚀 Performance improvements
- [ ] 🎨 Style changes (formatting, naming, etc.)
- [ ] 📦 Dependency updates
- [ ] 🔨 CI/CD changes

## Testing Checklist

- [x] Tests added or updated
- [x] All existing tests pass locally
- [x] Manual testing performed
- [x] Test coverage maintained or improved

**Test commands run:**
```bash
python3 .claude/skills/verify/tests/run_tests.py
```

**Test results:**

431/431 tests pass across all 17 modules. The new `test_suggest_branch_cleanup` module contributes 27 tests covering: `gh pr merge` triggers the advisory, all other Bash commands are silent, non-Bash tools are silent, and edge cases (invalid JSON, empty command) exit 0 cleanly.

## Documentation Checklist

- [ ] README.md updated (if user-facing changes)
- [x] Documentation updated (`rules/hooks-reference.md`)
- [x] Code comments added for complex logic
- [ ] API documentation updated (if API changes)

## Security Checklist

- [x] No secrets or credentials committed
- [x] Input validation implemented where needed
- [x] Security implications considered and documented
- [ ] Dependencies scanned for vulnerabilities
- [x] Authentication/authorization logic reviewed
- [x] Error messages don't leak sensitive information

## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] PR title follows Conventional Commits format

## Additional Context

**Reviewer Notes:**

The hook uses a Python regex to match `gh pr merge` as an actual command (not an argument to `echo` or similar) — the pattern checks for start-of-string, whitespace, `&&`, or `;` before the `gh` invocation. The advisory fires via `additionalContext` in the hook output JSON, which Claude Code surfaces as context without blocking execution.

The `global/CLAUDE.md` additions wire in four recently-created gotcha rule files that were missing from the Adopting New Technologies section, plus a new "Eval Run Setup" section referencing `eval-github-pat.md`.

**Follow-up Work:**

None planned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a post-merge advisory that suggests deleting feature branches (local and remote) and confirming linked issues are closed after successful PR merges.

* **Tests**
  * Added comprehensive tests covering merge variants, non-merge cases, invalid input, and tool-name edge cases.

* **Documentation**
  * Updated workflow guides and hooks reference with the new post-merge cleanup advisory and related gotchas.

* **Chores**
  * Registered the new advisory to run after relevant tool invocations and added a PROGRESS entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->