### PR TITLE
Extend suggest-write-prompt hook to cover PRDs, rules, and prompt files

### DIFF
--- a/.claude/skills/verify/scripts/suggest-write-prompt.sh
+++ b/.claude/skills/verify/scripts/suggest-write-prompt.sh
@@ -15,7 +15,10 @@ if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" ]]; then
   [ -z "$FILE_PATH" ] && exit 0
 
   BASENAME=$(basename "$FILE_PATH")
-  if [[ "$BASENAME" == "SKILL.md" || "$BASENAME" == "SKILL.v1-yolo.md" || "$BASENAME" == "CLAUDE.md" ]]; then
+  if [[ "$BASENAME" == "SKILL.md" || "$BASENAME" == "SKILL.v1-yolo.md" || "$BASENAME" == "CLAUDE.md" || \
+        "$FILE_PATH" == */prds/* || \
+        "$FILE_PATH" == */rules/* || \
+        "$BASENAME" == *-prompt.md || "$BASENAME" == *-spec.md ]]; then
     SUGGEST_FILE_PATH="$FILE_PATH" python3 -c "
 import json, os
 path = os.environ['SUGGEST_FILE_PATH']

--- a/.claude/skills/verify/scripts/suggest-write-prompt.sh
+++ b/.claude/skills/verify/scripts/suggest-write-prompt.sh
@@ -16,8 +16,8 @@ if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" ]]; then
 
   BASENAME=$(basename "$FILE_PATH")
   if [[ "$BASENAME" == "SKILL.md" || "$BASENAME" == "SKILL.v1-yolo.md" || "$BASENAME" == "CLAUDE.md" || \
-        "$FILE_PATH" == */prds/* || \
-        "$FILE_PATH" == */rules/* || \
+        "$FILE_PATH" == */prds/* || "$FILE_PATH" == prds/* || \
+        "$FILE_PATH" == */rules/* || "$FILE_PATH" == rules/* || \
         "$BASENAME" == *-prompt.md || "$BASENAME" == *-spec.md ]]; then
     SUGGEST_FILE_PATH="$FILE_PATH" python3 -c "
 import json, os

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,8 @@ Development progress log for claude-config. Tracks implementation milestones acr
 
 ### Added
 
+- (2026-05-13) Extended the `suggest-write-prompt` hook to fire for PRD files, rules files, and non-standard prompt filenames (`*-prompt.md`, `*-spec.md`) — previously it only reminded about `/write-prompt` for `SKILL.md` and `CLAUDE.md`, missing the many other file types that AI agents read and act on; added a 22-test bats suite covering all trigger and non-trigger cases
+
 - (2026-05-11) Committed accumulated agent-made changes: added 8 new technology gotcha rule files (TypeScript tsc CLI, LinkedIn REST API, IS scoring, mmdc/mermaid-cli, social video upload, gh fork, eval GitHub PAT, writing voice); expanded Kyverno gotchas with 5 new sections covering Crossplane/GKE instability patterns; expanded Weaver gotchas with 7 sections covering 0.21.2 and 0.22.1 breaking changes; expanded Micro.blog gotchas with 3 sections; added Quarto progressive reveal white-out technique; raised Anki card quality threshold to 12/15; updated global CLAUDE.md with journal preservation rules, Colima/Docker section, acceptance gate failure triage, and writing-voice.md reference; tightened /code-review skip criteria and added foreground-only constraint; added April 2026 journal entries and summaries
 
 - (2026-04-25) Added a post-merge advisory that prompts branch deletion locally and from the remote, and confirmation that any linked GitHub issue is closed — addressing a recurring pattern where merged PRs left follow-up cleanup incomplete; also added several missing technology gotcha references to the global development guide

--- a/tests/suggest-write-prompt.bats
+++ b/tests/suggest-write-prompt.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+# ABOUTME: Tests for suggest-write-prompt.sh PostToolUse hook
+# ABOUTME: Verifies the hook fires for all AI-consumed document types and stays silent otherwise
+
+SCRIPT="$BATS_TEST_DIRNAME/../.claude/skills/verify/scripts/suggest-write-prompt.sh"
+
+setup() {
+    TMPDIR="$(mktemp -d)"
+    chmod +x "$SCRIPT" 2>/dev/null || true
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+write_input() {
+    printf '%s' "$1" > "$TMPDIR/input.json"
+}
+
+# ── Existing triggers: must continue to fire ──────────────────────────────────
+
+@test "fires for Write on SKILL.md" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/.claude/skills/my-skill/SKILL.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+    [[ "$output" == *"write-prompt"* ]]
+}
+
+@test "fires for Edit on SKILL.v1-yolo.md" {
+    write_input '{"tool_name":"Edit","tool_input":{"file_path":"/repo/.claude/skills/my-skill/SKILL.v1-yolo.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "fires for Write on CLAUDE.md" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/CLAUDE.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+# ── New triggers: prds/ files ─────────────────────────────────────────────────
+
+@test "fires for Write on a prds/ file" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/prds/93-my-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "fires for Edit on a prds/ file" {
+    write_input '{"tool_name":"Edit","tool_input":{"file_path":"/repo/prds/93-my-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "fires for Edit on a prds/done/ file" {
+    write_input '{"tool_name":"Edit","tool_input":{"file_path":"/repo/prds/done/47-old-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+# ── New triggers: rules/ files ────────────────────────────────────────────────
+
+@test "fires for Write on a rules/ file" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/Users/whitney/.claude/rules/my-rule.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "fires for Edit on a rules/ file" {
+    write_input '{"tool_name":"Edit","tool_input":{"file_path":"/repo/rules/testing-rules.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+# ── New triggers: *-prompt.md and *-spec.md ───────────────────────────────────
+
+@test "fires for Write on a *-prompt.md file" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/system-prompt.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "fires for Write on a *-spec.md file" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/agent-spec.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "fires for Edit on a *-spec.md file" {
+    write_input '{"tool_name":"Edit","tool_input":{"file_path":"/repo/docs/crawler-spec.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+# ── Output format ─────────────────────────────────────────────────────────────
+
+@test "output is valid JSON with correct hookSpecificOutput schema" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/prds/93-my-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert d['hookSpecificOutput']['hookEventName'] == 'PostToolUse'
+assert 'additionalContext' in d['hookSpecificOutput']
+"
+}
+
+# ── Bash path: gh issue create ────────────────────────────────────────────────
+
+@test "bash path fires after successful gh issue create" {
+    fake_url="https://github.com/wiggitywhitney/claude-config/issues/99"
+    write_input "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --title test\"},\"tool_response\":\"$fake_url\"}"
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "bash path is silent for gh issue create that produced no github url" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh issue create --title test"},"tool_response":"error: could not create"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ── Negative cases: must stay silent ─────────────────────────────────────────
+
+@test "silent for Write on a plain markdown file" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/docs/README.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for Write on a shell script" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/scripts/deploy.sh"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for Write on a TypeScript file" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/src/index.ts"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for missing file_path" {
+    write_input '{"tool_name":"Write","tool_input":{}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for empty file_path" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":""}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for Bash tool on non-issue-create commands" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"git status"},"tool_response":"nothing to commit"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for gh issue list (not create)" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh issue list"},"tool_response":"#1 some issue"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for a file whose path happens to contain the word rules but is not in a rules/ dir" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/docs/business-rules-overview.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}

--- a/tests/suggest-write-prompt.bats
+++ b/tests/suggest-write-prompt.bats
@@ -103,6 +103,22 @@ write_input() {
     [[ "$output" == *"additionalContext"* ]]
 }
 
+# ── Relative path triggers ────────────────────────────────────────────────────
+
+@test "fires for Write on relative prds/ path (no leading slash)" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"prds/93-my-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "fires for Edit on relative rules/ path (no leading slash)" {
+    write_input '{"tool_name":"Edit","tool_input":{"file_path":"rules/testing-rules.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
 # ── Output format ─────────────────────────────────────────────────────────────
 
 @test "output is valid JSON with correct hookSpecificOutput schema" {


### PR DESCRIPTION
## Summary

- Extends the Write/Edit trigger in `suggest-write-prompt.sh` to also fire for files under `prds/`, files under `rules/`, and files named `*-prompt.md` or `*-spec.md`
- The hook's own message says "if an AI reads it and acts on it, it's a prompt" — this change makes the detection logic match that principle
- Adds `tests/suggest-write-prompt.bats` with 22 tests (all trigger and non-trigger cases)

Closes #93

## Test plan

- [ ] `bats tests/suggest-write-prompt.bats` — all 22 tests pass
- [ ] Manually edit a file in `prds/` and verify the hook fires in the session
- [ ] Verify SKILL.md, CLAUDE.md, and `gh issue create` triggers are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Prompt suggestion now triggers for a wider set of documents (PRDs, rules files, and additional prompt/spec markdown patterns) when using Write/Edit tools.

* **Tests**
  * Added a comprehensive test suite covering positive and negative trigger cases, relative paths, and related command behaviors.

* **Documentation**
  * Unreleased changelog entry documenting the extended trigger behavior and the new tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/claude-config/pull/95)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->