### PR TITLE
Add planning-handoff hook to check context capture after issue/PRD creation

### DIFF
--- a/.claude/skills/verify/scripts/suggest-planning-handoff.sh
+++ b/.claude/skills/verify/scripts/suggest-planning-handoff.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# ABOUTME: PostToolUse hook — prompts planning-handoff check after issue creation or new PRD file creation.
+# ABOUTME: Fires on Bash (gh issue create success) and Write (new prds/ file). Advisory only (exit 0 always).
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || echo "")
+
+emit_advisory() {
+  python3 -c "
+import json
+msg = (
+    'Planning handoff check: before this session ends, verify the document captures everything a future AI needs.\n\n'
+    '1. Decisions: Are there decisions from this conversation not in the document? '
+    'This includes rejected alternatives, constraints discovered mid-discussion, and the reason we did not do X.\n'
+    '2. Open questions: Are there open questions raised in this conversation that are not captured somewhere?\n'
+    '3. Cold AI test: Could a cold AI act on this document with only what is written, '
+    'or does it need something from this conversation to proceed?\n\n'
+    'If anything is missing, add it to the document now before moving on.'
+)
+print(json.dumps({
+    'hookSpecificOutput': {
+        'hookEventName': 'PostToolUse',
+        'additionalContext': msg
+    }
+}))
+"
+}
+
+# ── Path 1: Write tool — new PRD file creation ───────────────────────────────
+if [[ "$TOOL_NAME" == "Write" ]]; then
+  FILE_PATH=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null || echo "")
+  [ -z "$FILE_PATH" ] && exit 0
+
+  if [[ "$FILE_PATH" == */prds/* ]]; then
+    emit_advisory
+  fi
+  exit 0
+fi
+
+# ── Path 2: Bash — check for successful gh issue create ──────────────────────
+if [[ "$TOOL_NAME" == "Bash" ]]; then
+  RESULT=$(echo "$INPUT" | python3 -c "
+import json, sys, re
+
+data = json.load(sys.stdin)
+command = data.get('tool_input', {}).get('command', '')
+response = data.get('tool_response', {})
+
+# Only fire for gh issue create commands (not list, edit, comment, etc.)
+if not re.search(r'(^|\s|&&\s*|;\s*)gh\s+issue\s+create\b', command):
+    print('SKIP')
+    sys.exit(0)
+
+# Only fire on success — response must contain a GitHub issues URL
+stdout = str(response) if response else ''
+if 'github.com' not in stdout or '/issues/' not in stdout:
+    print('SKIP')
+    sys.exit(0)
+
+print('FIRE')
+" 2>/dev/null || echo "SKIP")
+
+  if [[ "$RESULT" == "FIRE" ]]; then
+    emit_advisory
+  fi
+  exit 0
+fi
+
+exit 0

--- a/.claude/skills/verify/scripts/suggest-planning-handoff.sh
+++ b/.claude/skills/verify/scripts/suggest-planning-handoff.sh
@@ -34,7 +34,7 @@ if [[ "$TOOL_NAME" == "Write" ]]; then
   FILE_PATH=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null || echo "")
   [ -z "$FILE_PATH" ] && exit 0
 
-  if [[ "$FILE_PATH" == */prds/* ]]; then
+  if [[ "$FILE_PATH" == */prds/* || "$FILE_PATH" == prds/* ]]; then
     emit_advisory
   fi
   exit 0

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,8 @@ Development progress log for claude-config. Tracks implementation milestones acr
 
 ### Added
 
+- (2026-05-13) Added `suggest-planning-handoff` hook — fires after `gh issue create` succeeds or a new PRD file is written; prompts the AI to check whether decisions, open questions, and cold-AI-actionability are captured before the planning session ends; solves the recurring problem of important planning conversation context not making it into the issue or PRD, requiring the conversation to happen again; 18-test bats suite
+
 - (2026-05-11) Committed accumulated agent-made changes: added 8 new technology gotcha rule files (TypeScript tsc CLI, LinkedIn REST API, IS scoring, mmdc/mermaid-cli, social video upload, gh fork, eval GitHub PAT, writing voice); expanded Kyverno gotchas with 5 new sections covering Crossplane/GKE instability patterns; expanded Weaver gotchas with 7 sections covering 0.21.2 and 0.22.1 breaking changes; expanded Micro.blog gotchas with 3 sections; added Quarto progressive reveal white-out technique; raised Anki card quality threshold to 12/15; updated global CLAUDE.md with journal preservation rules, Colima/Docker section, acceptance gate failure triage, and writing-voice.md reference; tightened /code-review skip criteria and added foreground-only constraint; added April 2026 journal entries and summaries
 
 - (2026-04-25) Added a post-merge advisory that prompts branch deletion locally and from the remote, and confirmation that any linked GitHub issue is closed — addressing a recurring pattern where merged PRs left follow-up cleanup incomplete; also added several missing technology gotcha references to the global development guide

--- a/config/settings.json
+++ b/config/settings.json
@@ -155,6 +155,10 @@
           {
             "type": "command",
             "command": "/Users/whitney.lee/Documents/Repositories/claude-config/.claude/skills/verify/scripts/cascade-decision-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "/Users/whitney.lee/Documents/Repositories/claude-config/.claude/skills/verify/scripts/suggest-planning-handoff.sh"
           }
         ]
       },
@@ -168,6 +172,10 @@
           {
             "type": "command",
             "command": "/Users/whitney.lee/Documents/Repositories/claude-config/.claude/skills/verify/scripts/suggest-branch-cleanup.sh"
+          },
+          {
+            "type": "command",
+            "command": "/Users/whitney.lee/Documents/Repositories/claude-config/.claude/skills/verify/scripts/suggest-planning-handoff.sh"
           }
         ]
       }

--- a/rules/hooks-reference.md
+++ b/rules/hooks-reference.md
@@ -37,7 +37,8 @@ Install with `bash scripts/install-git-hooks.sh [repo-path]`. The installer is i
 ## PostToolUse hooks (fire after tool execution)
 
 - **post-write-codeblock-check.sh** (PostToolUse: Write|Edit) — checks markdown files for bare code blocks missing language specifiers
-- **suggest-write-prompt.sh** (PostToolUse: Write|Edit, Bash) — advisory reminder to run `/write-prompt` when SKILL.md or CLAUDE.md files are edited, or when `gh issue create` succeeds; explains that any AI-consumed document is a prompt
+- **suggest-write-prompt.sh** (PostToolUse: Write|Edit, Bash) — advisory reminder to run `/write-prompt` when SKILL.md, CLAUDE.md, PRD files (`prds/`), rules files (`rules/`), or files named `*-prompt.md`/`*-spec.md` are edited, or when `gh issue create` succeeds; explains that any AI-consumed document is a prompt
+- **suggest-planning-handoff.sh** (PostToolUse: Write, Bash) — advisory prompt after `gh issue create` succeeds or a new PRD file is written (Write tool only, not Edit); asks three questions: were decisions captured, were open questions captured, could a cold AI act on this document alone; addresses context loss when planning conversations produce issues/PRDs that miss key discussion context
 - **suggest-branch-cleanup.sh** (PostToolUse: Bash) — advisory reminder to delete the feature branch locally and from the remote, and confirm the linked GitHub issue is closed, after `gh pr merge` commands
 - **cascade-decision-check.sh** (PostToolUse: Write|Edit) — advisory reminder to cascade-evaluate downstream milestones when a PRD file in `prds/` is edited; prompts Claude to check for new Decision Log rows and update affected milestones in the current and other open PRDs
 

--- a/tests/suggest-planning-handoff.bats
+++ b/tests/suggest-planning-handoff.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+# ABOUTME: Tests for suggest-planning-handoff.sh PostToolUse hook
+# ABOUTME: Verifies the hook fires after issue creation and new PRD file creation, and stays silent otherwise
+
+SCRIPT="$BATS_TEST_DIRNAME/../.claude/skills/verify/scripts/suggest-planning-handoff.sh"
+
+setup() {
+    TMPDIR="$(mktemp -d)"
+    chmod +x "$SCRIPT" 2>/dev/null || true
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+write_input() {
+    printf '%s' "$1" > "$TMPDIR/input.json"
+}
+
+# ── Positive: gh issue create ─────────────────────────────────────────────────
+
+@test "fires after successful gh issue create" {
+    fake_url="https://github.com/wiggitywhitney/claude-config/issues/94"
+    write_input "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --title test\"},\"tool_response\":\"$fake_url\"}"
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "advisory message contains the three planning-handoff questions" {
+    fake_url="https://github.com/wiggitywhitney/claude-config/issues/94"
+    write_input "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --title test\"},\"tool_response\":\"$fake_url\"}"
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"decisions"* ]]
+    [[ "$output" == *"open questions"* ]]
+    [[ "$output" == *"cold AI"* ]]
+}
+
+@test "output is valid JSON with correct hookSpecificOutput schema" {
+    fake_url="https://github.com/wiggitywhitney/claude-config/issues/94"
+    write_input "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --title test\"},\"tool_response\":\"$fake_url\"}"
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert d['hookSpecificOutput']['hookEventName'] == 'PostToolUse'
+assert 'additionalContext' in d['hookSpecificOutput']
+"
+}
+
+# ── Positive: Write tool on prds/ file (new file creation) ────────────────────
+
+@test "fires after Write tool creates a file under prds/" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/prds/94-my-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+@test "prds/ Write trigger also emits the three questions" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/prds/94-my-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"decisions"* ]]
+    [[ "$output" == *"open questions"* ]]
+    [[ "$output" == *"cold AI"* ]]
+}
+
+@test "fires after Write tool creates a file under prds/done/" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/prds/done/47-old-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
+# ── Negative: Edit on prds/ must NOT fire ────────────────────────────────────
+
+@test "silent for Edit on a prds/ file" {
+    write_input '{"tool_name":"Edit","tool_input":{"file_path":"/repo/prds/94-my-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ── Negative: other gh subcommands must NOT fire ──────────────────────────────
+
+@test "silent for gh issue list" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh issue list"},"tool_response":"#1 some issue"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for gh issue edit" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh issue edit 94 --body new body"},"tool_response":"https://github.com/wiggitywhitney/claude-config/issues/94"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for gh issue comment" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 94 --body test"},"tool_response":"https://github.com/wiggitywhitney/claude-config/issues/94"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for gh pr create" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh pr create --title test"},"tool_response":"https://github.com/wiggitywhitney/claude-config/pull/95"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for failed gh issue create (no github url in response)" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"gh issue create --title test"},"tool_response":"error: could not create"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ── Negative: Write on non-prds/ files must NOT fire ─────────────────────────
+
+@test "silent for Write on a SKILL.md file" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/.claude/skills/foo/SKILL.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for Write on a rules/ file" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/rules/my-rule.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for Write on a plain source file" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"/repo/scripts/deploy.sh"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for missing file_path in Write" {
+    write_input '{"tool_name":"Write","tool_input":{}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for empty file_path in Write" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":""}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent for git status bash command" {
+    write_input '{"tool_name":"Bash","tool_input":{"command":"git status"},"tool_response":"nothing to commit"}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}

--- a/tests/suggest-planning-handoff.bats
+++ b/tests/suggest-planning-handoff.bats
@@ -75,6 +75,13 @@ assert 'additionalContext' in d['hookSpecificOutput']
     [[ "$output" == *"additionalContext"* ]]
 }
 
+@test "fires after Write on relative prds/ path (no leading slash)" {
+    write_input '{"tool_name":"Write","tool_input":{"file_path":"prds/94-my-feature.md"}}'
+    run bash -c "\"$SCRIPT\" < \"$TMPDIR/input.json\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additionalContext"* ]]
+}
+
 # ── Negative: Edit on prds/ must NOT fire ────────────────────────────────────
 
 @test "silent for Edit on a prds/ file" {


### PR DESCRIPTION
## Summary

- Adds `suggest-planning-handoff.sh` — a new PostToolUse hook that fires after `gh issue create` succeeds or a new PRD file is created via the Write tool
- Prompts the AI with three questions: were decisions from this conversation captured, were open questions captured, and could a cold AI act on this document alone
- Solves the recurring problem of planning conversation context not making it into issues/PRDs, forcing the conversation to happen again with the next AI instance
- Registers the hook in `config/settings.json` under both Write|Edit and Bash matchers
- Documents the hook in `rules/hooks-reference.md`

Closes #94

## Test plan

- [ ] `bats tests/suggest-planning-handoff.bats` — all 18 tests pass
- [ ] `gh issue create` in a session fires the advisory prompt
- [ ] Writing a new file under `prds/` fires the advisory prompt
- [ ] Editing an existing PRD file does NOT fire (Edit tool excluded)
- [ ] `gh issue list`, `gh issue edit`, `gh pr create` do NOT fire

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a planning handoff advisory that triggers after successful GitHub issue creation or when new PRD files are written, prompting checks for decision capture, open questions, and actionability.

* **Documentation**
  * Updated hooks reference and progress log to document the new advisory and expanded trigger conditions for write/edit events and issue creation.

* **Tests**
  * Added comprehensive tests covering positive and negative trigger scenarios.

* **Chores**
  * Registered the new advisory in post-tool-use hook configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/claude-config/pull/96)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->