### PR TITLE
feat: add pre-commit advisory check for prompt generality

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,8 @@ Development progress log for claude-config. Tracks implementation milestones acr
 
 ### Added
 
+- (2026-05-31) Added `check-prompt-generality.sh` pre-commit advisory check — fires when `src/agent/prompt.ts` is staged in any repo; prints three diagnostic questions asking whether guidance is project-general, root-cause-based, and using synthetic namespaces (`my_service`, `acme`) rather than real eval-target namespaces; always exits 0 (advisory only); registered in the pre-commit dispatcher; 9-test bats suite
+
 - (2026-05-14) Added a mandatory `/write-prompt` quality review step to the `/prd-create` skill (both the standard and autonomous variants) — PRD milestones are instructions that future AI implementors execute directly, so they now get reviewed for prompt anti-patterns (vague directives, missing specifics, missing operationalization plans) before the PRD is committed; also added a PostToolUse advisory hook that fires whenever SKILL.md, CLAUDE.md, PRD, or rules files are edited, reminding the author to run `/write-prompt` since any AI-consumed document is a prompt
 
 - (2026-05-13) Added `suggest-planning-handoff` hook — fires after `gh issue create` succeeds or a new PRD file is written; prompts the AI to check whether decisions, open questions, and cold-AI-actionability are captured before the planning session ends; solves the recurring problem of important planning conversation context not making it into the issue or PRD, requiring the conversation to happen again; 19-test bats suite

--- a/hooks/git/checks/check-prompt-generality.sh
+++ b/hooks/git/checks/check-prompt-generality.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# ABOUTME: pre-commit advisory check — prints prompt generality questions when src/agent/prompt.ts is staged
+# ABOUTME: Never blocks the commit (always exits 0); silent when prompt file is not staged
+
+set -uo pipefail
+
+# Only fire when src/agent/prompt.ts is in the staged diff
+if ! git diff --cached --name-only | grep -q "^src/agent/prompt\.ts$"; then
+    exit 0
+fi
+
+{
+    echo ""
+    echo "ADVISORY: src/agent/prompt.ts is staged. Before committing, verify:"
+    echo ""
+    echo "  1. Does every piece of guidance express a principle that would apply to any project"
+    echo "     — not a specific eval target's function names or namespace?"
+    echo ""
+    echo "  2. Does every piece of guidance address a root cause rather than a symptom"
+    echo "     observed in one eval run?"
+    echo ""
+    echo "  3. Are all examples using synthetic namespaces (my_service, acme) rather than"
+    echo "     real eval-target namespaces (commit_story, taze, dd)?"
+    echo ""
+} >&2
+
+exit 0  # Advisory only — never blocks

--- a/hooks/git/pre-commit
+++ b/hooks/git/pre-commit
@@ -28,8 +28,9 @@ run_check() {
 
 exit_code=0
 
-run_check "$CHECKS_DIR/branch-protection.sh" || exit_code=$?
-run_check "$CHECKS_DIR/progress-md.sh"       || exit_code=$?
-run_check "$CHECKS_DIR/pre-commit-verify.sh" || exit_code=$?
+run_check "$CHECKS_DIR/branch-protection.sh"        || exit_code=$?
+run_check "$CHECKS_DIR/progress-md.sh"             || exit_code=$?
+run_check "$CHECKS_DIR/pre-commit-verify.sh"       || exit_code=$?
+run_check "$CHECKS_DIR/check-prompt-generality.sh" || exit_code=$?
 
 exit "$exit_code"

--- a/tests/check-prompt-generality.bats
+++ b/tests/check-prompt-generality.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# ABOUTME: Tests for hooks/git/checks/check-prompt-generality.sh
+# ABOUTME: Verifies advisory check fires only when src/agent/prompt.ts is staged
+
+CHECKS_DIR="$BATS_TEST_DIRNAME/../hooks/git/checks"
+
+setup() {
+    TMPDIR="$(mktemp -d)"
+    export GIT_REPO="$TMPDIR/testrepo"
+    export GIT_CONFIG_GLOBAL=/dev/null
+    git init "$GIT_REPO" --quiet
+    git -C "$GIT_REPO" config user.email "test@test.com"
+    git -C "$GIT_REPO" config user.name "Test"
+    git -C "$GIT_REPO" symbolic-ref HEAD refs/heads/main
+    touch "$GIT_REPO/.gitkeep"
+    git -C "$GIT_REPO" add .gitkeep
+    git -C "$GIT_REPO" commit -m "initial commit" --quiet
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+@test "check-prompt-generality: silent and exits 0 when nothing is staged" {
+    run bash -c "cd \"$GIT_REPO\" && \"$CHECKS_DIR/check-prompt-generality.sh\" 2>&1"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "check-prompt-generality: silent and exits 0 when unrelated file is staged" {
+    echo "some code" > "$GIT_REPO/other-file.ts"
+    git -C "$GIT_REPO" add other-file.ts
+    run bash -c "cd \"$GIT_REPO\" && \"$CHECKS_DIR/check-prompt-generality.sh\" 2>&1"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "check-prompt-generality: silent and exits 0 when similarly named file is staged" {
+    mkdir -p "$GIT_REPO/src/agent"
+    echo "other content" > "$GIT_REPO/src/agent/prompt-v2.ts"
+    git -C "$GIT_REPO" add src/agent/prompt-v2.ts
+    run bash -c "cd \"$GIT_REPO\" && \"$CHECKS_DIR/check-prompt-generality.sh\" 2>&1"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "check-prompt-generality: prints advisory when src/agent/prompt.ts is staged" {
+    mkdir -p "$GIT_REPO/src/agent"
+    echo "export const prompt = 'test';" > "$GIT_REPO/src/agent/prompt.ts"
+    git -C "$GIT_REPO" add src/agent/prompt.ts
+    run bash -c "cd \"$GIT_REPO\" && \"$CHECKS_DIR/check-prompt-generality.sh\" 2>&1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ADVISORY"* ]]
+}
+
+@test "check-prompt-generality: prints question 1 about principles applying to any project" {
+    mkdir -p "$GIT_REPO/src/agent"
+    echo "export const prompt = 'test';" > "$GIT_REPO/src/agent/prompt.ts"
+    git -C "$GIT_REPO" add src/agent/prompt.ts
+    run bash -c "cd \"$GIT_REPO\" && \"$CHECKS_DIR/check-prompt-generality.sh\" 2>&1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"any project"* ]]
+}
+
+@test "check-prompt-generality: prints question 2 about root cause vs symptom" {
+    mkdir -p "$GIT_REPO/src/agent"
+    echo "export const prompt = 'test';" > "$GIT_REPO/src/agent/prompt.ts"
+    git -C "$GIT_REPO" add src/agent/prompt.ts
+    run bash -c "cd \"$GIT_REPO\" && \"$CHECKS_DIR/check-prompt-generality.sh\" 2>&1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"root cause"* ]]
+}
+
+@test "check-prompt-generality: prints question 3 about synthetic namespaces" {
+    mkdir -p "$GIT_REPO/src/agent"
+    echo "export const prompt = 'test';" > "$GIT_REPO/src/agent/prompt.ts"
+    git -C "$GIT_REPO" add src/agent/prompt.ts
+    run bash -c "cd \"$GIT_REPO\" && \"$CHECKS_DIR/check-prompt-generality.sh\" 2>&1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"my_service"* ]]
+}
+
+@test "check-prompt-generality: exits 0 when src/agent/prompt.ts staged alongside other files" {
+    mkdir -p "$GIT_REPO/src/agent"
+    echo "export const prompt = 'test';" > "$GIT_REPO/src/agent/prompt.ts"
+    echo "other code" > "$GIT_REPO/src/other.ts"
+    git -C "$GIT_REPO" add src/agent/prompt.ts src/other.ts
+    run bash -c "cd \"$GIT_REPO\" && \"$CHECKS_DIR/check-prompt-generality.sh\" 2>&1"
+    [ "$status" -eq 0 ]
+}
+
+@test "check-prompt-generality: always exits 0 — never blocks commit" {
+    mkdir -p "$GIT_REPO/src/agent"
+    echo "export const prompt = 'test with commit_story namespace';" > "$GIT_REPO/src/agent/prompt.ts"
+    git -C "$GIT_REPO" add src/agent/prompt.ts
+    run bash -c "cd \"$GIT_REPO\" && \"$CHECKS_DIR/check-prompt-generality.sh\" 2>&1"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds `hooks/git/checks/check-prompt-generality.sh` — a pre-commit advisory check that fires when `src/agent/prompt.ts` is staged in any repo
- Prints three diagnostic questions asking whether guidance is project-general, root-cause-based, and uses synthetic namespaces (`my_service`, `acme`) rather than real eval-target namespaces
- Always exits 0 (advisory only, never blocks); registered in the pre-commit dispatcher

## Test plan

- [ ] 9 bats tests in `tests/check-prompt-generality.bats` all pass: `bats tests/check-prompt-generality.bats`
- [ ] Silent when nothing staged or when unrelated file staged
- [ ] Prints advisory with all three questions when `src/agent/prompt.ts` is staged
- [ ] Exits 0 in all cases
- [ ] Full suite passes: `bats tests/check-prompt-generality.bats tests/git-hook-checks.bats`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-commit advisory check that runs when prompt files are staged, providing diagnostic questions to verify prompt guidance principles and general applicability.

* **Tests**
  * Added comprehensive test suite to validate the new advisory check behavior across various scenarios and file configurations.

* **Documentation**
  * Updated progress log documenting the new pre-commit check and test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->